### PR TITLE
fix: update js-and-typescript.mdc

### DIFF
--- a/ai/js-and-typescript.mdc
+++ b/ai/js-and-typescript.mdc
@@ -1,7 +1,7 @@
 ---
 description: Style guide and best practices for writing JavaScript and TypeScript code
 globs: **/*.js,**/*.jsx,**/*.ts,**/*.tsx
-alwaysApply: true
+alwaysApply: false
 ---
 
 # JavaScript/TypeScript guide


### PR DESCRIPTION
Fix bug in rules.

Cursor would mistakenly include the quotes and read the rule as `"**.*js` which doesn't target any files and similarly `**/*.tsx"` which doesn't target any files, neither.

Also, `alwaysApply: true` ignores the glob pattern and includes the context for any file, which depletes attention capacity unnecessarily for unrelated files.