### PR TITLE
Fix

### DIFF
--- a/activity-log.md
+++ b/activity-log.md
@@ -1,5 +1,7 @@
 ## September 27, 2025
 
+- 🐛 - Fixed .mdc file glob patterns by removing quotes that prevented proper file targeting in Cursor rules
+- 🐛 - Corrected alwaysApply settings in .mdc files with globs to prevent conflicting rule application
 - 🔄 - Migrated from .sudo to .mdc file format for improved compatibility and standardization
 - 🔧 - Added .cursor symlink pointing to ai/ directory for enhanced agent orchestration
 - 📦 - Added package.json and release.js for automated version management and GitHub releases

--- a/ai/js-and-typescript.mdc
+++ b/ai/js-and-typescript.mdc
@@ -1,7 +1,7 @@
 ---
 description: Style guide and best practices for writing JavaScript and TypeScript code
-globs: "**/*.js,**/*.jsx,**/*.ts,**/*.tsx"
-alwaysApply: true
+globs: **/*.js,**/*.jsx,**/*.ts,**/*.tsx
+alwaysApply: false
 ---
 
 # JavaScript/TypeScript guide

--- a/ai/rules/javascript/javascript.mdc
+++ b/ai/rules/javascript/javascript.mdc
@@ -1,7 +1,7 @@
 ---
 description: When writing JavaScript or TypeScript code, use this guide for JavaScript best practices and guidance
-globs: "**/*.js,**/*.jsx,**/*.ts,**/*.tsx"
-alwaysApply: true
+globs: **/*.js,**/*.jsx,**/*.ts,**/*.tsx
+alwaysApply: false
 ---
 
 # JavaScript/TypeScript guide

--- a/ai/rules/review.mdc
+++ b/ai/rules/review.mdc
@@ -1,6 +1,6 @@
 ---
 description: Use this guide to conduct a thorough code review focusing on code quality, best practices, and adherence to project standards.
-globs: "**/*.js,**/*.jsx,**/*.ts,**/*.tsx"
+globs: **/*.js,**/*.jsx,**/*.ts,**/*.tsx
 alwaysApply: false
 ---
 # 🔬 Code Review

--- a/ai/rules/tdd.mdc
+++ b/ai/rules/tdd.mdc
@@ -1,7 +1,7 @@
 ---
 description: When implementing code changes, use this guide for systematic test-driven development with proper test isolation
-globs: "**/*.js,**/*.jsx,**/*.ts,**/*.tsx"
-alwaysApply: true
+globs: **/*.js,**/*.jsx,**/*.ts,**/*.tsx
+alwaysApply: false
 ---
 # TDD Engineer
 

--- a/ai/tdd.mdc
+++ b/ai/tdd.mdc
@@ -1,7 +1,7 @@
 ---
 description: When implementing code changes, use this guide for systematic test-driven development with proper test isolation
-globs: "**/*.js,**/*.jsx,**/*.ts,**/*.tsx"
-alwaysApply: true
+globs: **/*.js,**/*.jsx,**/*.ts,**/*.tsx
+alwaysApply: false
 ---
 # TDD Engineer
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sudolang.ai",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sudolang.ai",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "error-causes": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sudolang.ai",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SudoLang AI Assistant and Documentation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- 🐛 - Fixed .mdc file glob patterns by removing quotes that prevented proper file targeting in Cursor rules
- 🐛 - Corrected alwaysApply settings in .mdc files with globs to prevent conflicting rule application
