### PR TITLE
docs: add Vitest/Riteway test utils tips to TDD rules

### DIFF
--- a/ai/rules/tdd.mdc
+++ b/ai/rules/tdd.mdc
@@ -61,7 +61,7 @@ For Vitest/Riteway tests:
 - Spies and stubs: vi.fn and vi.spyOn
   - Vitest ships tinyspy under the hood. Simple, fast, and no extra deps.
 - Module mocking: vi.mock with vi.importActual for partial mocks
-  Works cleanly with ESM. Avoid require.
+  - Works cleanly with ESM. Avoid require.
 - Timers: vi.useFakeTimers and vi.setSystemTime
 
 Constraints {


### PR DESCRIPTION
Add default test utilities section covering:
- Spies and stubs using vi.fn and vi.spyOn
- Module mocking with vi.mock and vi.importActual
- Timer mocking with vi.useFakeTimers and vi.setSystemTime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
REVIEWER INSTRUCTIONS:
Please use the AI review command to conduct a thorough code review.
Run: ai/rules/review
Make sure to reference the JavaScript style guide: ai/rules/javascript/javascript.mdc
This will help ensure code quality, best practices, and adherence to project standards.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Default Test Utils section to the TDD guide covering spies/stubs, module mocking, and timers for Vitest/Riteway.
> 
> - **Docs**:
>   - Update `ai/rules/tdd.mdc` with a new **Default Test Utils** section for Vitest/Riteway:
>     - Spies/stubs: `vi.fn`, `vi.spyOn` (tinyspy under the hood)
>     - Module mocking: `vi.mock`, `vi.importActual` (ESM-friendly)
>     - Timers: `vi.useFakeTimers`, `vi.setSystemTime`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 930366266640cdb57b3b9bdf113cf2189f886ec0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->