### PR TITLE
Aidd create epic uri schemes

### DIFF
--- a/tasks/npx-aidd-create-epic.md
+++ b/tasks/npx-aidd-create-epic.md
@@ -18,7 +18,7 @@ New Commander subcommand `create [type] <folder>` added to `bin/aidd.js`.
 - Given `<type>` matching a scaffold name, should resolve to `ai/scaffolds/<type>` in the package
 - Given `<type>` as an HTTP/HTTPS URI, should treat it as a remote extension source
 - Given no `<type>` and no `AIDD_CUSTOM_EXTENSION_URI`, should use the bundled `ai/scaffolds/next-shadcn` extension
-- Given `AIDD_CUSTOM_EXTENSION_URI` env var is set and no `<type>` arg, should use the env URI (supports `http://`, `https://`, and `file://` schemes)
+- Given `AIDD_CUSTOM_CREATE_URI` env var is set and no `<type>` arg, should use the env URI (supports `https://` and `file://` schemes only — `http://` is rejected)
 - Given `--agent <name>` flag, should use that agent CLI for `prompt` steps (default: `claude`)
 - Given scaffold completes successfully, should suggest `npx aidd scaffold-cleanup` to remove downloaded extension files
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
REVIEWER INSTRUCTIONS:
Please use the AI review command to conduct a thorough code review.
Run: ai/rules/review
Make sure to reference the JavaScript style guide: ai/rules/javascript/javascript.mdc
This will help ensure code quality, best practices, and adherence to project standards.
-->
Corrected `tasks/npx-aidd-create-epic.md` to accurately reflect `AIDD_CUSTOM_CREATE_URI`'s supported schemes and environment variable name.

The documentation previously stated `http://` was supported, but the implementation explicitly rejects it for security reasons. This PR updates the spec to show that only `https://` and `file://` are supported, and `http://` is rejected. Additionally, the environment variable name was corrected from `AIDD_CUSTOM_EXTENSION_URI` to `AIDD_CUSTOM_CREATE_URI` to match the actual code.

This is a documentation-only fix to ensure consistency between the specification and the code's behavior.

---
<p><a href="https://cursor.com/agents/bc-38fe7837-a1a6-4152-9ae3-195fe361c583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38fe7837-a1a6-4152-9ae3-195fe361c583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->