### PR TITLE
Node.js engine requirement

### DIFF
--- a/lib/exports.test.js
+++ b/lib/exports.test.js
@@ -127,4 +127,17 @@ describe("package.json exports configuration", () => {
       expected: true,
     });
   });
+
+  test("declares Node.js engine requirement", async () => {
+    const pkg = await import("../package.json", { with: { type: "json" } });
+    const nodeEngine = pkg.default.engines?.node;
+
+    assert({
+      given: "a user on Node < 18",
+      should:
+        "declare engines.node to surface a clear version error at install time",
+      actual: nodeEngine,
+      expected: ">=18",
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
     "toc": "doctoc README.md",
     "typecheck": "tsc --noEmit && echo 'Type check complete.'"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "sideEffects": false,
   "type": "module",
   "version": "2.6.0"

--- a/tasks/npx-aidd-create-epic.md
+++ b/tasks/npx-aidd-create-epic.md
@@ -9,6 +9,13 @@ Today there's no way to bootstrap a new project from the AIDD ecosystem — devs
 
 ---
 
+## Node.js engine requirement
+
+**Requirements**:
+- Given a user is on Node < 18, should receive a clear version constraint error from npm/node at install or run time — not a confusing runtime `ReferenceError`
+
+---
+
 ## Add `create` subcommand
 
 New Commander subcommand `create [type] <folder>` added to `bin/aidd.js`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
REVIEWER INSTRUCTIONS:
Please use the AI review command to conduct a thorough code review.
Run: ai/rules/review
Make sure to reference the JavaScript style guide: ai/rules/javascript/javascript.mdc
This will help ensure code quality, best practices, and adherence to project standards.
-->
### Fix: Add Node.js engine requirement to package.json

**Problem:**
`lib/scaffold-resolver.js` uses the global `fetch` API, available only in Node.js 18+. Previously, `package.json` lacked an `engines` field, causing users on older Node.js versions to encounter a cryptic `ReferenceError: fetch is not defined` at runtime.

**Solution:**
Added `"engines": { "node": ">=18" }` to `package.json`.

**Why:**
This change ensures that users on Node.js versions older than 18 receive a clear version constraint error from npm/node at install or run time, preventing confusing runtime `ReferenceError` messages.

**Impact:**
- Improved user experience with clearer error messages for incompatible Node.js versions.
- Explicitly declares the minimum Node.js version requirement.

**Testing:**
- Added a new unit test in `lib/exports.test.js` to assert the `engines.node` field.
- Confirmed the new test failed before the fix and passed after.
- All 184 unit tests and 29 e2e tests passed.
- Lint and type checks are clean.

**Additional Changes:**
- Documented the requirement in `tasks/npx-aidd-create-epic.md`.

---
<p><a href="https://cursor.com/agents/bc-033ac3c0-fced-4096-9883-9cd64b8df552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-033ac3c0-fced-4096-9883-9cd64b8df552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->