### PR TITLE
fix(test): quote cliPath in create-e2e to handle paths with spaces

### DIFF
--- a/bin/create-e2e.test.js
+++ b/bin/create-e2e.test.js
@@ -17,7 +17,7 @@ import {
 const execAsync = promisify(exec);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const cliPath = path.join(__dirname, "./aidd.js");
+const cliPath = `"${path.join(__dirname, "./aidd.js")}"`;
 
 // Shared state for the scaffold-example create tests (runs npm install once)
 const scaffoldExampleCtx = {


### PR DESCRIPTION
<!--
REVIEWER INSTRUCTIONS:
Please use the AI review command to conduct a thorough code review.
Run: ai/rules/review
Make sure to reference the JavaScript style guide: ai/rules/javascript/javascript.mdc
This will help ensure code quality, best practices, and adherence to project standards.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that only affects how the e2e suite invokes the CLI; minimal behavioral impact outside of improving path robustness.
> 
> **Overview**
> Updates `bin/create-e2e.test.js` to wrap the computed `cliPath` in quotes before interpolating it into `execAsync` commands, preventing e2e test failures when the CLI script path contains spaces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f59970d2f6b81085dd35dac599c29591a4b594e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->