### PR TITLE
ci: add automated PR review workflow using Claude

### DIFF
--- a/.github/workflows/aidd-review-claude.yml
+++ b/.github/workflows/aidd-review-claude.yml
@@ -76,7 +76,7 @@ jobs:
                    ```
             }
           claude_args: |
-            --model claude-sonnet-4-6 --max-turns 20 --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(echo:*),Bash(npx:*),mcp__github_inline_comment__create_inline_comment" --disallowedTools "Task,Write,Edit"
+            --model claude-sonnet-4-6 --max-turns 20 --allowedTools "Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(echo:*),Bash(npx aidd:*),mcp__github_inline_comment__create_inline_comment" --disallowedTools "Task,Write,Edit"
 
       - name: Post summary comment
         if: always()


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/aidd-review-claude.yml` — a GitHub Actions workflow that automatically reviews non-draft PRs using Claude Code with the `aidd-review` skill
- Posts inline comments on specific files/lines and a full review summary comment
- Uploads the Claude execution log as a build artifact for debugging

## Prerequisites
- The `ANTHROPIC_API_KEY` secret must be configured in the repo settings

## Test plan
- [ ] Open a draft PR and verify the workflow does **not** run
- [ ] Mark the PR as ready for review and verify the workflow triggers
- [ ] Confirm inline comments appear on changed files
- [ ] Confirm a summary comment is posted on the PR
- [ ] Verify the `claude-review-log` artifact is uploaded