### PR TITLE
feat: add AI prompt evaluation tests for the review skill

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,49 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  ai-eval:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Check Claude authentication
+        id: claude-auth
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️ Skipping AI evals: CLAUDE_CODE_OAUTH_TOKEN not set"
+          fi
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Run AI prompt evaluations
+        if: steps.claude-auth.outputs.available == 'true'
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: npm run test:ai-eval
+
+      - name: Upload AI eval responses
+        if: always() && steps.claude-auth.outputs.available == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-eval-responses
+          path: ai-evals/*.responses.md
+          retention-days: 14

--- a/ai-evals/aidd-review/fixtures/data-fetch.js
+++ b/ai-evals/aidd-review/fixtures/data-fetch.js
@@ -1,0 +1,54 @@
+const fetchUserData = async (userId) => {
+  // Using || instead of parameter defaults for fallback
+  const id = userId || "anonymous";
+
+  const response = await fetch(`/api/users/${encodeURIComponent(id)}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch user: ${response.status}`);
+  }
+
+  const data = await response.json();
+
+  // IIFE instead of block scope
+  const processed = (() => {
+    const name = data.name;
+    const email = data.email;
+    return { email, id, name };
+  })();
+
+  return processed;
+};
+
+// Unnecessary intermediate variables instead of point-free composition
+const formatUsers = (users) => {
+  const activeUsers = users.filter((u) => u.active);
+  const names = activeUsers.map((u) => u.name);
+  const sorted = names.sort();
+  return sorted;
+};
+
+// ALL_CAPS constant naming
+const MAX_RETRY_COUNT = 3;
+const DEFAULT_TIMEOUT_MS = 5000;
+
+const retryFetch = async (url, options) => {
+  let attempts = 0; // let instead of functional recursion
+  while (attempts < MAX_RETRY_COUNT) {
+    try {
+      return await fetch(url, options);
+    } catch (e) {
+      attempts++;
+      if (attempts >= MAX_RETRY_COUNT) throw e;
+      await new Promise((resolve) => setTimeout(resolve, DEFAULT_TIMEOUT_MS));
+    }
+  }
+};
+
+export {
+  fetchUserData,
+  formatUsers,
+  retryFetch,
+  MAX_RETRY_COUNT,
+  DEFAULT_TIMEOUT_MS,
+};

--- a/ai-evals/aidd-review/fixtures/user-service.js
+++ b/ai-evals/aidd-review/fixtures/user-service.js
@@ -1,0 +1,83 @@
+import crypto from "crypto";
+
+class BaseModel {
+  constructor(db) {
+    this.db = db;
+  }
+
+  save(table, data) {
+    const columns = Object.keys(data).join(", ");
+    const values = Object.values(data).join("', '");
+    return this.db.query(
+      `INSERT INTO ${table} (${columns}) VALUES ('${values}')`,
+    );
+  }
+}
+
+class UserService extends BaseModel {
+  constructor(db) {
+    super(db);
+    this.users = [];
+  }
+
+  async createUser(name, email, role) {
+    this.users.push({ email, name, role });
+    return this.save("users", { email, name, role });
+  }
+
+  async findUser(username) {
+    const result = await this.db.query(
+      `SELECT * FROM users WHERE username = '${username}'`,
+    );
+    return result[0];
+  }
+
+  async deleteUser(id) {
+    return this.db.query(`DELETE FROM users WHERE id = ${id}`);
+  }
+
+  renderUserProfile(user) {
+    const container = document.getElementById("profile");
+    container.innerHTML = `
+      <h1>${user.name}</h1>
+      <p>${user.bio}</p>
+      <div>${user.website}</div>
+    `;
+  }
+
+  verifyApiKey(candidateKey, storedKey) {
+    return candidateKey === storedKey;
+  }
+
+  verifyToken(candidate, stored) {
+    const a = Buffer.from(candidate);
+    const b = Buffer.from(stored);
+    return crypto.timingSafeEqual(a, b);
+  }
+
+  async authenticate(req) {
+    const token = req.headers.authorization;
+    const password = token;
+    const isValid = this.verifyApiKey(password, process.env.API_KEY);
+    if (isValid) {
+      console.log("Auth successful for token:", token);
+      return true;
+    }
+    return false;
+  }
+
+  processUsers(userList) {
+    const result = [];
+    // biome-ignore lint/style/useForOf: index needed
+    for (let i = 0; i < userList.length; i++) {
+      if (userList[i].active) {
+        const user = userList[i];
+        user.processed = true;
+        result.push(user);
+      }
+    }
+    return result;
+  }
+}
+
+export default UserService;

--- a/ai-evals/aidd-review/fixtures/utils.js
+++ b/ai-evals/aidd-review/fixtures/utils.js
@@ -1,0 +1,47 @@
+import { createHash } from "crypto";
+
+/**
+ * Hashes a value with SHA3-256.
+ */
+const hashSecret = (secret = "") =>
+  createHash("sha3-256").update(secret).digest("hex");
+
+/**
+ * Compares two secrets by hashing both before comparison.
+ */
+const compareSecrets = (candidate = "", stored = "") =>
+  hashSecret(candidate) === hashSecret(stored);
+
+const isActive = (user = {}) => Boolean(user.active);
+
+const getDisplayName = ({ firstName = "", lastName = "" } = {}) =>
+  `${firstName} ${lastName}`.trim();
+
+const filterActiveUsers = (users = []) => users.filter(isActive);
+
+const getActiveUserNames = (users = []) =>
+  filterActiveUsers(users).map(getDisplayName);
+
+const createUser = ({
+  id = "",
+  firstName = "",
+  lastName = "",
+  email = "",
+  active = false,
+} = {}) => ({
+  active,
+  email,
+  firstName,
+  id,
+  lastName,
+});
+
+export {
+  hashSecret,
+  compareSecrets,
+  isActive,
+  getDisplayName,
+  filterActiveUsers,
+  getActiveUserNames,
+  createUser,
+};

--- a/ai-evals/aidd-review/review-skill-test.sudo
+++ b/ai-evals/aidd-review/review-skill-test.sudo
@@ -1,0 +1,21 @@
+import 'ai/skills/aidd-review/SKILL.md'
+
+userPrompt = """
+Run /review on the three fixture files in ai-evals/aidd-review/fixtures/:
+- user-service.js
+- utils.js
+- data-fetch.js
+"""
+
+- Given user-service.js builds SQL queries with string concatenation, should flag SQL injection vulnerability
+- Given user-service.js assigns unsanitized user input to innerHTML, should flag XSS vulnerability
+- Given user-service.js uses class and extends keywords, should flag class usage as a best practice violation
+- Given user-service.js compares secrets with === operator, should flag timing-unsafe secret comparison
+- Given user-service.js uses imperative for loop with push and mutation, should flag imperative style and input mutation
+- Given user-service.js logs the auth token to console, should flag sensitive data exposure in logs
+- Given utils.js uses pure functions with parameter defaults, should not flag any major violations
+- Given utils.js hashes secrets before comparison, should recognize correct timing-safe pattern
+- Given data-fetch.js uses || for defaults instead of parameter defaults, should flag || default pattern as a style issue
+- Given data-fetch.js uses an IIFE instead of a block scope, should flag IIFE usage
+- Given data-fetch.js uses ALL_CAPS constant naming, should flag ALL_CAPS naming convention violation
+- Given the complete review, should explicitly list all current OWASP top 10 categories

--- a/ai/skills/aidd-review/SKILL.md
+++ b/ai/skills/aidd-review/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools: Read Grep Glob Bash(git:*)
 Act as a top-tier principal software engineer to conduct a thorough code review focusing on code quality, best practices, and adherence to requirements, plan, and project standards.
 
 Criteria {
+  Important: The skill references below (e.g. /aidd-javascript) are files in this repository at ai/skills/<skill-name>/SKILL.md. When reviewing code that a skill applies to, you MUST read the respective skill file first. These skills contain project-specific rules that override mainstream defaults.
   Before beginning, read and respect the constraints in /aidd-please.
   Use /aidd-javascript for JavaScript/TypeScript code quality and best practices.
   Use /aidd-tdd for test coverage and test quality assessment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "doctoc": "^2.2.1",
         "husky": "^9.1.7",
         "release-it": "^19.0.5",
-        "riteway": "^9.0.0-rc.1",
+        "riteway": "^9.2.0",
         "vitest": "^3.2.4"
       },
       "engines": {
@@ -1522,9 +1522,9 @@
       }
     },
     "node_modules/@paralleldrive/cuid2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-3.1.0.tgz",
-      "integrity": "sha512-UhTJsF2XGlIFmGGTUKBfmNCX+B/UCv3w0OHhq2CJIsfH33GN1lkgjATozG+Pf7s3ACcUdM4qaWgzy4Rr8PlUdA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-3.3.0.tgz",
+      "integrity": "sha512-OqiFvSOF0dBSesELYY2CAMa4YINvlLpvKOz/rv6NeZEqiyttlHgv98Juwv4Ch+GrEV7IZ8jfI2VcEoYUjXXCjw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.0.1",
@@ -2594,9 +2594,9 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
-      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2605,11 +2605,11 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
+        "undici": "^7.19.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -2940,9 +2940,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4223,9 +4223,9 @@
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -4238,14 +4238,14 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/htmlparser2/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4685,6 +4685,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-inside-container": {
@@ -6324,6 +6337,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/protocols": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
@@ -6380,16 +6406,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
-      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.1.1"
+        "react": "^19.2.4"
       }
     },
     "node_modules/readdirp": {
@@ -6623,20 +6649,204 @@
       }
     },
     "node_modules/riteway": {
-      "version": "9.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/riteway/-/riteway-9.0.0-rc.1.tgz",
-      "integrity": "sha512-r6XrvFX9FSce/yG/HOsNtDqyh4E25k55PXLvGn4d2bR5dQqzB5jhpfSgzsdCtHE6kWNZrIaMJZ9aoB0wn63W9A==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/riteway/-/riteway-9.2.0.tgz",
+      "integrity": "sha512-rMQgNausO1TCL3JxAV90PNuYEVqxwnXxYk02tA4PWzksWKq9ZXFZ8+IjuY/hFigyxU/uc4Wy7r/51NDF1zEZCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cheerio": "1.1.2",
+        "@paralleldrive/cuid2": "^3.3.0",
+        "cheerio": "1.2.0",
+        "dotignore": "^0.1.2",
+        "error-causes": "^3.0.2",
         "esm": "3.2.25",
-        "react-dom": "19.1.1",
+        "glob": "^11.0.3",
+        "minimist": "^1.2.8",
+        "open": "^11.0.0",
+        "react-dom": "^19.2.0",
+        "resolve": "^1.22.10",
         "tape": "^5.9.0",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.4",
+        "zod": "^4.3.6"
       },
       "bin": {
-        "riteway": "bin/riteway"
+        "riteway": "bin/riteway.js"
+      }
+    },
+    "node_modules/riteway/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/riteway/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/riteway/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/riteway/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/riteway/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/riteway/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/riteway/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/riteway/node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/riteway/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/riteway/node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/riteway/node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rollup": {
@@ -6777,9 +6987,9 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7668,9 +7878,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
-      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7983,6 +8193,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8299,6 +8510,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   "description": "The standard framework for AI Driven Development.",
   "devDependencies": {
     "@biomejs/biome": "2.3.12",
-    "@types/js-yaml": "^4.0.9",
     "@types/fs-extra": "^11.0.4",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.3.3",
     "@vitest/coverage-v8": "^3.2.4",
     "doctoc": "^2.2.1",
     "husky": "^9.1.7",
     "release-it": "^19.0.5",
-    "riteway": "^9.0.0-rc.1",
+    "riteway": "^9.2.0",
     "vitest": "^3.2.4"
   },
   "exports": {
@@ -97,6 +97,7 @@
     "prepare": "husky",
     "release": "node release.js",
     "test": "vitest run && echo 'Test complete.' && npm run -s lint && npm run -s typecheck",
+    "test:ai-eval": "riteway ai ai-evals/aidd-review/review-skill-test.sudo --runs 4 --threshold 75 --timeout 600000 --agent claude --color --save-responses",
     "test:e2e": "vitest run **/*-e2e.test.js && echo 'E2E tests complete.'",
     "test:unit": "vitest run --exclude '**/*-e2e.test.js' && echo 'Unit tests complete.' && npm run -s lint && npm run -s typecheck",
     "toc": "doctoc README.md",


### PR DESCRIPTION
## Summary
- Add `riteway ai` integration tests that validate the review skill catches security vulnerabilities, style violations, and best practice issues
- Bump riteway from 9.0.0-rc.1 to 9.1.0 (which includes the new `riteway ai` CLI)
- Add 3 fixture files with neutral names (`user-service.js`, `utils.js`, `data-fetch.js`) and no hint comments — file names and contents are deliberately non-descriptive so the review skill doesn't know it's being tested
- Add `.sudo` test file with 12 assertions covering OWASP, JS best practices, and review completeness
- Add `npm run test:ai-eval` script and separate `ai-eval` CI job
- CI uses `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) to bill against existing Claude subscription — not per-token API
- CI skips gracefully if the token isn't configured yet

## Setup required
Once merged, Eric needs to:
1. Run `claude setup-token` locally
2. Add the output as a GitHub repo secret named `CLAUDE_CODE_OAUTH_TOKEN`
3. Re-run the action to verify

## Test plan
- [x] All 346 existing unit tests pass
- [x] Lint passes (single biome-ignore on intentional `for` loop)
- [ ] Run `npm run test:ai-eval` locally once `CLAUDE_CODE_OAUTH_TOKEN` is set
- [ ] Verify CI `ai-eval` job skips gracefully without the token
- [ ] Verify CI `ai-eval` job runs successfully once the token is added