### PR TITLE
feat: add aidd-review-rust skill

### DIFF
--- a/ai/commands/aidd-review-rust.md
+++ b/ai/commands/aidd-review-rust.md
@@ -1,0 +1,10 @@
+---
+description: Review Rust code for correctness, safety, and idiomatic patterns
+---
+# 🦀 /aidd-review-rust
+
+Load and execute the skill at `ai/skills/aidd-review-rust/SKILL.md`.
+
+Constraints {
+  Before beginning, read and respect the constraints in /aidd-please.
+}

--- a/ai/skills/aidd-review-rust/README.md
+++ b/ai/skills/aidd-review-rust/README.md
@@ -1,0 +1,26 @@
+# aidd-review-rust
+
+Rust-specific code review criteria for correctness, safety, ownership, and
+idiomatic patterns.
+
+## Why
+
+Rust's ownership model and unsafe escape hatches create review-specific
+concerns that general code review misses. Systematic checks for unwrap
+discipline, lock scopes across await, slice types in APIs, and unsafe
+invariant documentation catch bugs that compile but are semantically wrong.
+
+## Usage
+
+Invoke `/aidd-review-rust` when reviewing Rust code. The skill runs grep-based
+detection from a checklist, then evaluates six priority areas: safety,
+security, ownership, async correctness, type design, and test quality. Every
+finding cites file:line with the wrong pattern and the correct fix.
+
+Referenced automatically by `/aidd-review` when Rust code is in the diff.
+
+## When to use
+
+- Reviewing Rust pull requests or diffs
+- Auditing Rust code for safety and correctness
+- Evaluating Rust code quality before merge

--- a/ai/skills/aidd-review-rust/SKILL.md
+++ b/ai/skills/aidd-review-rust/SKILL.md
@@ -72,7 +72,7 @@ Priority3_Ownership {
 
 Priority4_Async {
   `std::sync::Mutex` guard held across `.await` => flag. Deadlock risk.
-  `tokio::sync::Mutex` guard held across `.await` unnecessarily => flag. Blocks other tasks.
+  Async-aware mutex guard (e.g. `tokio::sync::Mutex`) held across `.await` longer than necessary => flag. Narrow the critical section.
   `std::fs::` in async functions => flag. Use the runtime's async fs (e.g. `tokio::fs::`, `async_std::fs::`).
   `std::thread::sleep` in async context => flag. Use the runtime's async sleep or `spawn_blocking`.
 }

--- a/ai/skills/aidd-review-rust/SKILL.md
+++ b/ai/skills/aidd-review-rust/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: aidd-review-rust
+description: Rust code review criteria for correctness, safety, ownership, and idiomatic patterns. Use when reviewing Rust code, Rust PRs, or auditing Rust codebases.
+allowed-tools: Read Grep Glob Bash(git:*)
+---
+
+# 🦀 Rust Code Review
+
+Act as a principal Rust engineer conducting a thorough code review focused on correctness, safety, and idiomatic Rust patterns.
+
+Competencies {
+  Rust safety and correctness (unwrap/expect/panic discipline)
+  ownership and borrowing (slices over owned types, clone elimination)
+  async safety (lock scopes, blocking detection)
+  security (constant-time comparison, unsafe invariant documentation, injection prevention)
+  type design (enums over booleans, newtypes for type safety)
+  Rust test quality (async test macros, assertion presence, env soundness)
+}
+
+Constraints {
+  Don't make changes. Review-only. Output serves as input for planning.
+  Avoid unfounded assumptions. If unsure, note and ask.
+  Use references/rust-checklist.md for grep-based detection of patterns.
+  Every finding must cite file:line and show the wrong pattern and the correct fix.
+  Only flag patterns that are deterministically wrong. Skip judgment calls.
+  #[cfg(test)] modules: .unwrap() is acceptable in test code.
+  main() functions: .expect() is acceptable as the top-level error boundary.
+  Mixed Rust/C FFI: unsafe at FFI boundaries is expected but still requires // SAFETY: comments.
+  Generated code (protobuf, bindgen): skip ownership and style checks.
+  no_std crates: async and tokio rules do not apply.
+}
+
+For each step, show your work:
+    🎯 restate |> 💡 ideate |> 🪞 reflectCritically |> 🔭 expandOrthogonally |> ⚖️ scoreRankEvaluate |> 💬 respond
+
+ReviewProcess {
+  1. Run grep checks from references/rust-checklist.md against changed files
+  2. Review error handling: no unwrap/expect in fallible paths, proper Result propagation
+  3. Review ownership: borrows over clones, correct slice types in APIs
+  4. Review async safety: no locks held across .await, proper runtime usage
+  5. Review security: constant-time comparisons, no unsafe without SAFETY comments, input validation at boundaries
+  6. Review type design: enums for exclusive states, newtypes for type safety
+  7. Review test quality: async test macros, assertions present, no unsound env mutation
+  8. Scan for anti-patterns using the Priority criteria below
+  9. Provide actionable findings with specific file:line references and fix suggestions
+}
+
+Priority1_Safety {
+  `.unwrap()` in non-test code => flag. Use `?`, `unwrap_or`, `expect("invariant reason")`, or match.
+  `.expect()` on user input or network results => flag. `expect` is only for programmer invariants.
+  `panic!()`, `unreachable!()` on recoverable conditions => flag. Return Result instead.
+  Missing error context => flag when `?` propagates without `.context()` or `.map_err()` and the caller cannot determine which operation failed.
+}
+
+Priority2_Security {
+  `==` comparing secrets, tokens, or API keys => flag. Use `subtle::ConstantTimeEq` or hash-then-compare.
+  `unsafe {}` without `// SAFETY:` comment => flag. Every unsafe block must document its invariants.
+  `format!()` interpolating user input into SQL, shell commands, or HTML => flag. Use parameterized queries, Command API, or templating with escaping.
+  Session cookies missing HttpOnly, Secure, or SameSite attributes => flag.
+  Sensitive data in error messages or logs (passwords, tokens, keys) => flag.
+}
+
+Priority3_Ownership {
+  `&Vec<T>` in function params => flag. Accept `&[T]`.
+  `&String` in function params => flag. Accept `&str`.
+  `&PathBuf` in function params => flag. Accept `&Path`.
+  `.clone()` where a borrow would work => flag. Borrow instead.
+  `.to_string()` or `.to_owned()` inside a loop on the same value => flag. Hoist outside loop.
+}
+
+Priority4_Async {
+  `std::sync::Mutex` guard held across `.await` => flag. Deadlock risk.
+  `tokio::sync::Mutex` guard held across `.await` unnecessarily => flag. Blocks other tasks.
+  `std::fs::` in async functions => flag. Use `tokio::fs::`.
+  `std::thread::sleep` in async context => flag. Use `tokio::time::sleep`.
+}
+
+Priority5_TypeDesign {
+  Boolean flags for mutually exclusive states => flag. Use an enum.
+  Stringly-typed fields where an enum or newtype fits => flag.
+  Public `Result`-returning functions missing `#[must_use]` => note.
+  Public enums without `#[non_exhaustive]` in library code => note.
+}
+
+Priority6_Testing {
+  Async tests not using `#[tokio::test]` => flag.
+  Tests without assertions => flag.
+  `std::env::set_var` in multi-threaded test context => flag. Unsound since Rust 1.66.
+}
+
+Commands {
+  🦀 /aidd-review-rust - review Rust code for correctness, safety, and idiomatic patterns
+}

--- a/ai/skills/aidd-review-rust/SKILL.md
+++ b/ai/skills/aidd-review-rust/SKILL.md
@@ -50,6 +50,7 @@ Priority1_Safety {
   `.expect()` on user input or network results => flag. `expect` is only for programmer invariants.
   `panic!()`, `unreachable!()` on recoverable conditions => flag. Return Result instead.
   Missing error context => flag when `?` propagates without `.context()` or `.map_err()` and the caller cannot determine which operation failed.
+  Empty error-handling arms (`Err(_) => {}`, `.ok()` discarding actionable errors) => flag. Handle or propagate the error.
 }
 
 Priority2_Security {
@@ -64,6 +65,7 @@ Priority3_Ownership {
   `&Vec<T>` in function params => flag. Accept `&[T]`.
   `&String` in function params => flag. Accept `&str`.
   `&PathBuf` in function params => flag. Accept `&Path`.
+  `&Box<T>` in function params => flag. Accept `&T`.
   `.clone()` where a borrow would work => flag. Borrow instead.
   `.to_string()` or `.to_owned()` inside a loop on the same value => flag. Hoist outside loop.
 }

--- a/ai/skills/aidd-review-rust/SKILL.md
+++ b/ai/skills/aidd-review-rust/SKILL.md
@@ -73,8 +73,8 @@ Priority3_Ownership {
 Priority4_Async {
   `std::sync::Mutex` guard held across `.await` => flag. Deadlock risk.
   `tokio::sync::Mutex` guard held across `.await` unnecessarily => flag. Blocks other tasks.
-  `std::fs::` in async functions => flag. Use `tokio::fs::`.
-  `std::thread::sleep` in async context => flag. Use `tokio::time::sleep`.
+  `std::fs::` in async functions => flag. Use the runtime's async fs (e.g. `tokio::fs::`, `async_std::fs::`).
+  `std::thread::sleep` in async context => flag. Use the runtime's async sleep or `spawn_blocking`.
 }
 
 Priority5_TypeDesign {
@@ -85,7 +85,7 @@ Priority5_TypeDesign {
 }
 
 Priority6_Testing {
-  Async tests not using `#[tokio::test]` => flag.
+  Async tests using plain `#[test]` instead of a runtime-specific macro (e.g. `#[tokio::test]`, `#[async_std::test]`) => flag.
   Tests without assertions => flag.
   `std::env::set_var` in multi-threaded test context => flag. Unsound since Rust 1.66.
 }

--- a/ai/skills/aidd-review-rust/references/rust-checklist.md
+++ b/ai/skills/aidd-review-rust/references/rust-checklist.md
@@ -122,7 +122,7 @@ Flag `.clone()` when the value is only read after the clone. If the cloned value
 ### Locks across await
 
 `std::sync::Mutex` guard across `.await` => deadlock. Always wrong.
-`tokio::sync::Mutex` guard across `.await` => blocks other tasks. Wrong unless the critical section requires the await (rare).
+Async-aware mutex guard (e.g. `tokio::sync::Mutex`, `async_std::sync::Mutex`) across `.await` => blocks other tasks. Wrong unless the critical section requires the await (rare). Narrow the critical section.
 
 Fix: extract needed data from the lock scope, release the guard, then await.
 

--- a/ai/skills/aidd-review-rust/references/rust-checklist.md
+++ b/ai/skills/aidd-review-rust/references/rust-checklist.md
@@ -19,7 +19,9 @@ std::thread::sleep  — should be tokio::time::sleep in async code
 &Vec<              — should be &[T] in function params
 &String            — should be &str in function params
 &PathBuf           — should be &Path in function params
+&Box<              — should be &T in function params
 .clone()            — verify borrow would not suffice
+Err(_) =>          — check for silently swallowed errors
 format!(.* user     — check for injection via user input interpolation
 password            — verify not logged or included in error messages
 token               — verify not logged or included in error messages
@@ -52,6 +54,29 @@ let data = serde_json::from_reader(file)?;
 // Clear: caller knows exactly what failed
 let file = File::open(path).map_err(|e| AppError::FileOpen { path, source: e })?;
 let data = serde_json::from_reader(file).context("parsing config")?;
+```
+
+### Silently swallowed errors
+
+`Err(_) => {}`, `Err(_) => ()`, or `.ok()` on a Result whose error carries actionable information. Silent discard hides bugs.
+
+Deterministic rule:
+- Empty `Err(_)` match arms => always wrong
+- `.ok()` discarding I/O, network, or parse errors => always wrong
+- `let _ = tx.send(...)` in shutdown/cleanup paths => acceptable (receiver may be dropped)
+
+```rust
+// ALWAYS WRONG: error silently ignored
+match do_work() {
+    Ok(v) => v,
+    Err(_) => {}
+}
+
+// CORRECT: log, propagate, or convert
+match do_work() {
+    Ok(v) => v,
+    Err(e) => return Err(e.into()),
+}
 ```
 
 ## Priority 2: Security

--- a/ai/skills/aidd-review-rust/references/rust-checklist.md
+++ b/ai/skills/aidd-review-rust/references/rust-checklist.md
@@ -13,8 +13,8 @@ unsafe {            — must have // SAFETY: comment above
 .lock().            — check if guard is held across .await
 .read().            — check if RwLock guard is held across .await
 .write().           — check if RwLock guard is held across .await
-std::fs::           — should be tokio::fs:: in async code
-std::thread::sleep  — should be tokio::time::sleep in async code
+std::fs::           — should use runtime's async fs in async code
+std::thread::sleep  — should use runtime's async sleep in async code
 == "               — check if comparing secrets (needs constant-time)
 &Vec<              — should be &[T] in function params
 &String            — should be &str in function params
@@ -131,8 +131,8 @@ Fix: extract needed data from the lock scope, release the guard, then await.
 `std::fs::*`, `std::thread::sleep`, CPU-heavy computation in async context blocks the tokio runtime thread pool.
 
 Fixes:
-- `tokio::fs::*` for file I/O
-- `tokio::time::sleep` for delays
+- Runtime's async fs (`tokio::fs::*`, `async_std::fs::*`) for file I/O
+- Runtime's async sleep (`tokio::time::sleep`, `async_std::task::sleep`) for delays
 - `tokio::task::spawn_blocking` for CPU-heavy work
 
 ## Priority 5: Type Design
@@ -157,11 +157,11 @@ Bare `u64` or `String` used as different kinds of IDs (user ID, order ID) that s
 
 ### Async test macros
 
-`#[test]` on an async fn does not execute the future. Must use `#[tokio::test]`.
+`#[test]` on an async fn does not execute the future. Must use a runtime-specific macro (e.g. `#[tokio::test]`, `#[async_std::test]`).
 
 ### Environment mutation
 
-`std::env::set_var` and `std::env::remove_var` are unsound in multi-threaded programs since Rust 1.66. In `#[tokio::test]` (multi-threaded by default), this is a data race.
+`std::env::set_var` and `std::env::remove_var` are unsound in multi-threaded programs since Rust 1.66. In multi-threaded async test runtimes (e.g. `#[tokio::test]`), this is a data race.
 
 ## Code Examples
 

--- a/ai/skills/aidd-review-rust/references/rust-checklist.md
+++ b/ai/skills/aidd-review-rust/references/rust-checklist.md
@@ -1,0 +1,189 @@
+# Rust Review Checklist
+
+Grep-based detection patterns and expanded guidance for each review priority.
+
+## Quick Grep Checks
+
+Run these against non-test source files to surface candidates for review:
+
+```
+.unwrap()           — potential panic in production code
+.expect(            — verify it documents a programmer invariant, not user input
+unsafe {            — must have // SAFETY: comment above
+.lock().            — check if guard is held across .await
+.read().            — check if RwLock guard is held across .await
+.write().           — check if RwLock guard is held across .await
+std::fs::           — should be tokio::fs:: in async code
+std::thread::sleep  — should be tokio::time::sleep in async code
+== "               — check if comparing secrets (needs constant-time)
+&Vec<              — should be &[T] in function params
+&String            — should be &str in function params
+&PathBuf           — should be &Path in function params
+.clone()            — verify borrow would not suffice
+format!(.* user     — check for injection via user input interpolation
+password            — verify not logged or included in error messages
+token               — verify not logged or included in error messages
+secret              — verify not logged or included in error messages
+api_key             — verify not logged or included in error messages
+```
+
+## Priority 1: Safety & Correctness
+
+### unwrap/expect in production code
+
+`.unwrap()` panics without context. `.expect()` is only for invariants that represent programmer bugs, not runtime conditions.
+
+Deterministic rule:
+- `.unwrap()` on I/O, network, parsing, or user input => always wrong
+- `.expect()` on I/O, network, parsing, or user input => always wrong
+- `.unwrap()` on `Some(literal)` or infallible operations => acceptable
+
+Fixes: `?` operator, `.unwrap_or()`, `.unwrap_or_default()`, `match`, `if let`
+
+### Error propagation without context
+
+Bare `?` on operations where the caller cannot distinguish which step failed.
+
+```rust
+// Ambiguous: which step failed?
+let file = File::open(path)?;
+let data = serde_json::from_reader(file)?;
+
+// Clear: caller knows exactly what failed
+let file = File::open(path).map_err(|e| AppError::FileOpen { path, source: e })?;
+let data = serde_json::from_reader(file).context("parsing config")?;
+```
+
+## Priority 2: Security
+
+### Constant-time comparison
+
+Any `==` or `!=` comparing secrets, tokens, API keys, HMAC digests, or session identifiers is a timing side-channel.
+
+Correct approaches:
+- `subtle::ConstantTimeEq` for byte-level comparison
+- Hash both inputs to fixed-width digest (SHA-256), then compare digests with `ct_eq`
+- `ring::constant_time::verify_slices_are_equal`
+
+### Unsafe blocks
+
+Every `unsafe {}` must have a `// SAFETY:` comment directly above explaining why the invariants are upheld. No exceptions.
+
+### Sensitive data exposure
+
+Grep for `password`, `token`, `secret`, `api_key`, `credential` in:
+- `tracing::info!`, `tracing::debug!`, `log::info!`, `println!`
+- Error message strings in `format!`, `.context()`, `thiserror` display attributes
+- HTTP response bodies (JSON error responses)
+
+## Priority 3: Ownership
+
+### Slice types in APIs
+
+Deterministic rule with no exceptions in function signatures:
+- `&Vec<T>` => `&[T]`
+- `&String` => `&str`
+- `&PathBuf` => `&Path`
+- `&Box<T>` => `&T`
+
+The owned type in params forces callers to allocate unnecessarily. The borrowed form accepts any compatible source via Deref coercion.
+
+### Clone vs borrow
+
+Flag `.clone()` when the value is only read after the clone. If the cloned value is not mutated or moved into a struct/return, a borrow suffices.
+
+## Priority 4: Async
+
+### Locks across await
+
+`std::sync::Mutex` guard across `.await` => deadlock. Always wrong.
+`tokio::sync::Mutex` guard across `.await` => blocks other tasks. Wrong unless the critical section requires the await (rare).
+
+Fix: extract needed data from the lock scope, release the guard, then await.
+
+### Blocking in async
+
+`std::fs::*`, `std::thread::sleep`, CPU-heavy computation in async context blocks the tokio runtime thread pool.
+
+Fixes:
+- `tokio::fs::*` for file I/O
+- `tokio::time::sleep` for delays
+- `tokio::task::spawn_blocking` for CPU-heavy work
+
+## Priority 5: Type Design
+
+### Enums over booleans
+
+Two or more boolean fields that represent mutually exclusive states should be an enum.
+
+```rust
+// Wrong: impossible state (both true)
+struct Connection { is_connected: bool, is_connecting: bool }
+
+// Correct: impossible states are unrepresentable
+enum ConnectionState { Disconnected, Connecting, Connected }
+```
+
+### Newtypes for distinct identifiers
+
+Bare `u64` or `String` used as different kinds of IDs (user ID, order ID) that should not be interchangeable.
+
+## Priority 6: Testing
+
+### Async test macros
+
+`#[test]` on an async fn does not execute the future. Must use `#[tokio::test]`.
+
+### Environment mutation
+
+`std::env::set_var` and `std::env::remove_var` are unsound in multi-threaded programs since Rust 1.66. In `#[tokio::test]` (multi-threaded by default), this is a data race.
+
+## Code Examples
+
+### unwrap on network result
+
+```rust
+// ALWAYS WRONG: unwrap on network result
+let body = response.json::<User>().await.unwrap();
+// CORRECT:
+let body = response.json::<User>().await?;
+```
+
+### Slice type in API
+
+```rust
+// ALWAYS WRONG: owned type in API params
+fn process(items: &Vec<String>) { ... }
+// CORRECT:
+fn process(items: &[String]) { ... }
+```
+
+### std mutex guard across await
+
+```rust
+// ALWAYS WRONG: lock held across await
+let guard = data.lock().unwrap();
+do_work().await;
+guard.push(item);
+// CORRECT: extract, release, then await
+let val = { data.lock().unwrap().last().copied() };
+let result = do_work(val).await;
+data.lock().unwrap().push(result);
+```
+
+### String equality for secrets
+
+```rust
+// ALWAYS WRONG: timing side-channel
+if provided_token == expected_token { grant_access(); }
+// CORRECT:
+use subtle::ConstantTimeEq;
+if provided_token.as_bytes().ct_eq(expected_token.as_bytes()).into() { grant_access(); }
+```
+
+## Sources
+
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- [Clippy Lint Documentation](https://rust-lang.github.io/rust-clippy/stable/)
+- [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+- Crate documentation: `subtle`, `argon2`, `tokio`, `axum`

--- a/ai/skills/aidd-review/SKILL.md
+++ b/ai/skills/aidd-review/SKILL.md
@@ -12,6 +12,7 @@ Criteria {
   Important: The skill references below (e.g. /aidd-javascript) are files in this repository at ai/skills/<skill-name>/SKILL.md. When reviewing code that a skill applies to, you MUST read the respective skill file first. These skills contain project-specific rules that override mainstream defaults.
   Before beginning, read and respect the constraints in /aidd-please.
   Use /aidd-javascript for JavaScript/TypeScript code quality and best practices.
+  Use /aidd-review-rust for Rust code correctness, safety, ownership, and idiomatic patterns.
   Use /aidd-tdd for test coverage and test quality assessment.
   Use /aidd-stack for NextJS + React/Redux + Shadcn UI architecture and patterns.
   Use /aidd-ui for UI/UX design and component quality.

--- a/ai/skills/index.md
+++ b/ai/skills/index.md
@@ -19,6 +19,7 @@
 - aidd-product-manager - Plan features, user stories, user journeys, and conduct product discovery. Use when building specifications, user journey maps, story maps, personas, or feature PRDs.
 - aidd-react - Enforces React component authoring best practices. Use when creating React components, binding components, presentations, useObservableValues, or when the user asks about React UI patterns, reactive binding, or action callbacks.
 - aidd-review - Conduct a thorough code review focusing on code quality, best practices, security, test coverage, and adherence to project standards and functional requirements. Use when reviewing code, pull requests, or completed epics.
+- aidd-review-rust - Rust code review criteria for correctness, safety, ownership, and idiomatic patterns. Use when reviewing Rust code, Rust PRs, or auditing Rust codebases.
 - aidd-service - Enforces asynchronous data service authoring best practices. Use when creating front-end or back-end services, service interfaces, Observe patterns, AsyncDataService, or when the user asks about service layer, data flow, unidirectional UI, or action/observable design.
 - aidd-stack - Tech stack guidance for NextJS + React/Redux + Shadcn UI features. Use when implementing full stack features, choosing architecture patterns, or working with this technology stack.
 - aidd-structure - Enforces source code structuring and interdependency best practices. Use when creating folders, moving files, adding imports, or when the user asks about architecture, layering, or module dependencies.


### PR DESCRIPTION
## Summary

- Add `aidd-review-rust` skill — Rust-specific code review criteria for correctness, safety, and idiomatic patterns
- Wire into `/aidd-review` Criteria block so Rust code is picked up automatically during general reviews
- Add command wrapper, README, and skills index entry

## What the skill covers

Six priority-ranked review areas, each with deterministic rules (no judgment calls):

1. **Safety** — `.unwrap()`/`.expect()` discipline, panic on recoverable conditions, missing error context with bare `?`
2. **Security** — constant-time comparison for secrets (`subtle::ConstantTimeEq`), `unsafe` blocks without `// SAFETY:` comments, format injection, sensitive data in logs
3. **Ownership** — `&Vec<T>`/`&String`/`&PathBuf` in params (should be `&[T]`/`&str`/`&Path`), unnecessary `.clone()`
4. **Async** — `std::sync::Mutex` guards held across `.await`, blocking I/O (`std::fs::`, `std::thread::sleep`) in async context
5. **Type design** — boolean flags for exclusive states (should be enums), stringly-typed fields, missing `#[must_use]`/`#[non_exhaustive]`
6. **Testing** — async tests without `#[tokio::test]`, missing assertions, `std::env::set_var` unsoundness since Rust 1.66

Includes a grep-based checklist (`references/rust-checklist.md`) with 18 detection patterns and code examples for each priority.

Edge cases are handled: `#[cfg(test)]` allows `.unwrap()`, `main()` allows `.expect()`, FFI `unsafe` is expected, generated code is skipped, `no_std` ignores async rules.

## Changed files

| File | Change |
|------|--------|
| `ai/skills/aidd-review-rust/SKILL.md` | New skill: frontmatter, competencies, constraints, review process, 6 priority blocks, commands |
| `ai/skills/aidd-review-rust/README.md` | Human-readable documentation (why, usage, when to use) |
| `ai/skills/aidd-review-rust/references/rust-checklist.md` | Grep patterns, expanded guidance per priority, code examples |
| `ai/commands/aidd-review-rust.md` | Command wrapper with description frontmatter |
| `ai/skills/aidd-review/SKILL.md` | Add `/aidd-review-rust` to Criteria block |
| `ai/skills/index.md` | Add alphabetical index entry |

## Test plan

- [ ] Invoke `/aidd-review-rust` on a Rust codebase and verify findings cite file:line with wrong/correct patterns
- [ ] Invoke `/aidd-review` on a mixed diff containing Rust files and verify it loads the Rust criteria
- [ ] Confirm `ai/skills/index.md` entry is alphabetically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)