### PR TITLE
fix(release): exclude e2e tests from pre-release hook

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -17,7 +17,7 @@
       "node lib/update-latest-tag-hook.js ${version}",
       "echo 🎉 Successfully released ${name} v${version}"
     ],
-    "before:init": ["npm test"]
+    "before:init": ["npm run test:unit"]
   },
   "npm": {
     "publish": true


### PR DESCRIPTION
Replace `npm test` with `npm run test:unit` in the release-it `before:init` hook so e2e tests don't run during releases.

Made-with: Cursor

<!--
REVIEWER INSTRUCTIONS:
Please use the AI review command to conduct a thorough code review.
Run: ai/commands/review.md
Make sure to reference the JavaScript style guide: ai/skills/aidd-javascript/SKILL.md
This will help ensure code quality, best practices, and adherence to project standards.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config change limited to the release workflow; it only alters which test script runs before tagging/publishing.
> 
> **Overview**
> Updates `release-it`’s `before:init` hook to run `npm run test:unit` instead of `npm test`, so releases execute unit/lint/typecheck checks while skipping e2e tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea0c360c4ccc97458c4f571e8239cae3664fcb1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->