### PR TITLE
docs: add critical dependencies epic (PR #168 → #181 → #184)

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -2,6 +2,12 @@
 
 ## Current Epics
 
+### 📋 Critical Dependencies Epic
+
+**Status**: 📋 PLANNED  
+**File**: [`tasks/aidd-critical-dependencies-epic.md`](./tasks/aidd-critical-dependencies-epic.md)  
+**Goal**: Land the foundational PRs that unblock `/aidd-parallel`, `/aidd-genesplice`, and downstream work — in dependency order (PR #168 → #181 → #184)
+
 ### 📋 `aidd create --prompt` Epic
 
 **Status**: 📋 PLANNED  

--- a/tasks/aidd-critical-dependencies-epic.md
+++ b/tasks/aidd-critical-dependencies-epic.md
@@ -1,0 +1,38 @@
+# Critical Dependencies Epic
+
+**Status**: 📋 PLANNED
+**Goal**: Land the foundational PRs that unblock `/aidd-parallel`, `/aidd-genesplice`, and downstream work — in dependency order.
+
+## Overview
+
+Several open PRs form a dependency chain: downstream skills like `/aidd-genesplice` cannot be completed until the `/aidd-parallel` infrastructure in PR #168 merges. Landing these in the wrong order causes merge conflicts and duplicated effort. This epic tracks the critical path so each PR lands in sequence, unblocking the next.
+
+---
+
+## Merge PR #168 — `/aidd-parallel` foundation
+
+PR #168 (`cursor/aidd-config-json-support-24c1`) delivers `/aidd-parallel` (including the `/aidd-parallel delegate` subcommand), updated `/aidd-pr`, `/aidd-requirements`, and `/aidd-riteway-ai`. 37 files, +1098 lines. This is the root blocker — nothing else lands until this merges.
+
+**Requirements**:
+- Given PR #168 is open, should complete review and merge to `main` before any dependent PR
+- Given PR #168 delivers `/aidd-parallel delegate`, should verify the sub-agent delegation interface is stable before merging dependents
+
+---
+
+## Merge PR #181 — `/aidd-genesplice` base skill
+
+PR #181 (`cursor/new-genesplice-skill-4389`) adds the base `/aidd-genesplice` evolutionary optimization skill. Depends on PR #168 for sub-agent delegation via `/aidd-parallel`.
+
+**Requirements**:
+- Given PR #168 is merged, should rebase PR #181 onto `main` and resolve any conflicts
+- Given the base genesplice skill, should verify it integrates with the `/aidd-parallel delegate` interface delivered by PR #168
+
+---
+
+## Merge PR #184 — `/aidd-genesplice` task epic and functional requirements
+
+PR #184 (`cursor/genesplice-skill-epic-dc29`) adds the task epic with functional requirements for remaining genesplice work: sub-agent isolation, pipeline subcommands, `--output` flag, and deterministic CLI tests. Depends on PR #181.
+
+**Requirements**:
+- Given PR #181 is merged, should rebase PR #184 onto `main` and resolve any conflicts
+- Given the genesplice epic defines pipeline subcommands and `--output` flag, should verify requirements do not conflict with the `/aidd-parallel` interface from PR #168


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
REVIEWER INSTRUCTIONS:
Please use the AI review command to conduct a thorough code review.
Run: ai/commands/review.md
Make sure to reference the JavaScript style guide: ai/skills/aidd-javascript/SKILL.md
This will help ensure code quality, best practices, and adherence to project standards.
-->

## Summary

Tracks #182 — adds `tasks/aidd-critical-dependencies-epic.md` documenting the critical dependency chain and landing order for the foundational PRs.

## Dependency Chain (order of operations)

1. **PR #168** (`cursor/aidd-config-json-support-24c1`) — `/aidd-parallel` skill (root blocker). Includes `/aidd-parallel delegate`, updated `/aidd-pr`, `/aidd-requirements`, `/aidd-riteway-ai`. 37 files, +1098 lines.
2. **PR #181** (`cursor/new-genesplice-skill-4389`) — `/aidd-genesplice` base skill. Depends on PR #168 for sub-agent delegation.
3. **PR #184** (`cursor/genesplice-skill-epic-dc29`) — `/aidd-genesplice` task epic with functional requirements (sub-agent isolation, pipeline subcommands, `--output` flag, deterministic CLI tests). Depends on PR #181.

## Changes

- `tasks/aidd-critical-dependencies-epic.md` — new epic file following `/aidd-task` format
- `plan.md` — added epic reference to current epics section
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d6416bd-0f67-4d80-afac-524e084b7ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d6416bd-0f67-4d80-afac-524e084b7ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

