### PR TITLE
docs: add PR #94 split plan and updated landing order to critical dependencies epic

### DIFF
--- a/tasks/aidd-critical-dependencies-epic.md
+++ b/tasks/aidd-critical-dependencies-epic.md
@@ -5,34 +5,124 @@
 
 ## Overview
 
-Several open PRs form a dependency chain: downstream skills like `/aidd-genesplice` cannot be completed until the `/aidd-parallel` infrastructure in PR #168 merges. Landing these in the wrong order causes merge conflicts and duplicated effort. This epic tracks the critical path so each PR lands in sequence, unblocking the next.
+Several open PRs form a dependency chain and some bundle multiple skills that must be split before merging. PR #94 contains 27 files spanning `/aidd-rtc`, `/aidd-upskill`, modified existing skills, and infrastructure — all need separate PRs. PR #168 bundles `/aidd-parallel`, `/aidd-pr`, and eval infrastructure. Landing these in the wrong order causes merge conflicts and duplicated effort. This epic tracks the critical path so each skill lands as its own PR, in sequence.
+
+## Design Decisions
+
+- `/aidd-parallel delegate` (from PR #168) is the canonical delegate design
+- PR #179's standalone `/aidd-delegate` is superseded — only `/aidd-pipeline` from that PR is needed
+- One skill per PR rule — multi-skill PRs must be split before merge
 
 ---
 
-## Merge PR #168 — `/aidd-parallel` foundation
+## Split and merge `/aidd-rtc` from PR #94
 
-PR #168 (`cursor/aidd-config-json-support-24c1`) delivers `/aidd-parallel` (including the `/aidd-parallel delegate` subcommand), updated `/aidd-pr`, `/aidd-requirements`, and `/aidd-riteway-ai`. 37 files, +1098 lines. This is the root blocker — nothing else lands until this merges.
+Split the 3 `/aidd-rtc` files out of PR #94 into a standalone PR. Zero dependencies — merge first.
+
+**Files**: `ai/commands/aidd-rtc.md`, `ai/skills/aidd-rtc/SKILL.md`, `ai/skills/aidd-rtc/README.md`
 
 **Requirements**:
-- Given PR #168 is open, should complete review and merge to `main` before any dependent PR
-- Given PR #168 delivers `/aidd-parallel delegate`, should verify the sub-agent delegation interface is stable before merging dependents
+- Given `/aidd-rtc` has zero dependencies on other unmerged PRs, should land first in the sequence
+- Given PR #94 bundles 27 files across multiple skills, should split `/aidd-rtc` into its own PR before merging
+
+---
+
+## Split and merge `/aidd-pipeline` from PR #179
+
+Split `/aidd-pipeline` out of PR #179 into a standalone PR. PR #179's standalone `/aidd-delegate` is superseded by `/aidd-parallel delegate`.
+
+**Requirements**:
+- Given `/aidd-rtc` is merged, should split and land `/aidd-pipeline` next
+- Given PR #179 also contains a standalone `/aidd-delegate`, should exclude `/aidd-delegate` — it is superseded by `/aidd-parallel delegate` from PR #168
+
+---
+
+## Split and merge `/aidd-parallel` (with `delegate` subcommand) from PR #168
+
+Split `/aidd-parallel` (including `/aidd-parallel delegate`) out of PR #168 into its own PR. This is the canonical sub-agent delegation interface.
+
+**Requirements**:
+- Given `/aidd-pipeline` is merged, should split and land `/aidd-parallel` next
+- Given `/aidd-parallel delegate` is the canonical delegate design, should verify the delegation interface is stable before merging dependents
+
+---
+
+## Split and merge `/aidd-pr` from PR #168
+
+Split `/aidd-pr` out of PR #168 into its own PR.
+
+**Requirements**:
+- Given `/aidd-parallel` is merged, should split and land `/aidd-pr` next
+
+---
+
+## Split and merge eval infrastructure from PR #168
+
+Split the eval infrastructure files out of PR #168 into their own PR.
+
+**Requirements**:
+- Given `/aidd-pr` is merged, should split and land eval infrastructure next
+- Given eval infrastructure supports downstream skills, should verify eval harness works before merging `/aidd-upskill`
+
+---
+
+## Split and merge `/aidd-upskill` from PR #94
+
+Split the remaining `/aidd-upskill` files (11 files) out of PR #94. Depends on `/aidd-rtc`.
+
+**Files**: `ai/commands/aidd-upskill.md`, `ai/skills/aidd-upskill/` (SKILL.md, README.md, index.md, references/\*, scripts/\*), `ai-evals/aidd-upskill/` (4 eval files + 3 fixtures)
+
+**Requirements**:
+- Given `/aidd-rtc` and eval infrastructure are merged, should split and land `/aidd-upskill` next
+- Given PR #94 modifies 3 existing skills (`aidd-agent-orchestrator`, `aidd-please`, `aidd-review`), should triage each modification to determine if it belongs with `/aidd-rtc` or `/aidd-upskill` and include accordingly
+
+---
+
+## Triage modified existing skills from PR #94
+
+PR #94 modifies `ai/skills/aidd-agent-orchestrator/SKILL.md`, `ai/skills/aidd-please/SKILL.md`, and `ai/skills/aidd-review/SKILL.md`. These changes must be assigned to the correct split PR.
+
+**Requirements**:
+- Given 3 existing skills are modified in PR #94, should review each diff to determine whether the change is rtc-related or upskill-related
+- Given the one-skill-per-PR rule, should include each modified skill in the PR whose feature it supports
+
+---
+
+## Triage infrastructure files from PR #94
+
+PR #94 modifies `ai/commands/index.md`, `ai/skills/index.md`, `package.json`, and `.gitignore`. These go with whichever split PR they support.
+
+**Requirements**:
+- Given infrastructure files are shared across skills, should include each file in the earliest PR that requires the change
 
 ---
 
 ## Merge PR #181 — `/aidd-genesplice` base skill
 
-PR #181 (`cursor/new-genesplice-skill-4389`) adds the base `/aidd-genesplice` evolutionary optimization skill. Depends on PR #168 for sub-agent delegation via `/aidd-parallel`.
+PR #181 adds the base `/aidd-genesplice` evolutionary optimization skill. Depends on `/aidd-parallel` for sub-agent delegation.
 
 **Requirements**:
-- Given PR #168 is merged, should rebase PR #181 onto `main` and resolve any conflicts
-- Given the base genesplice skill, should verify it integrates with the `/aidd-parallel delegate` interface delivered by PR #168
+- Given `/aidd-upskill` is merged, should rebase PR #181 onto `main` and resolve any conflicts
+- Given the base genesplice skill, should verify it integrates with the `/aidd-parallel delegate` interface
 
 ---
 
 ## Merge PR #184 — `/aidd-genesplice` task epic and functional requirements
 
-PR #184 (`cursor/genesplice-skill-epic-dc29`) adds the task epic with functional requirements for remaining genesplice work: sub-agent isolation, pipeline subcommands, `--output` flag, and deterministic CLI tests. Depends on PR #181.
+PR #184 adds the task epic with functional requirements for remaining genesplice work. Depends on PR #181.
 
 **Requirements**:
 - Given PR #181 is merged, should rebase PR #184 onto `main` and resolve any conflicts
-- Given the genesplice epic defines pipeline subcommands and `--output` flag, should verify requirements do not conflict with the `/aidd-parallel` interface from PR #168
+- Given the genesplice epic defines pipeline subcommands and `--output` flag, should verify requirements do not conflict with the `/aidd-parallel` interface
+
+---
+
+## Full Landing Order
+
+1. `/aidd-rtc` — split from PR #94
+2. `/aidd-pipeline` — split from PR #179
+3. `/aidd-parallel` (includes `delegate` subcommand) — split from PR #168
+4. `/aidd-pr` — split from PR #168
+5. Eval infrastructure — split from PR #168
+6. `/aidd-upskill` — split from PR #94
+7. `/aidd-genesplice` — PR #181 + PR #184


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
REVIEWER INSTRUCTIONS:
Please use the AI review command to conduct a thorough code review.
Run: ai/commands/review.md
Make sure to reference the JavaScript style guide: ai/skills/aidd-javascript/SKILL.md
This will help ensure code quality, best practices, and adherence to project standards.
-->

## Summary

Updates `tasks/aidd-critical-dependencies-epic.md` with PR #94 split plan and a revised full landing order across all open PRs.

## What changed

### PR #94 split plan added
PR #94 (27 files) bundles multiple skills — must be split before merge:
- **`/aidd-rtc`** (3 files, zero deps) — lands first in the sequence
- **`/aidd-upskill`** (11 files, depends on rtc + eval infra)
- **Modified existing skills** (`aidd-agent-orchestrator`, `aidd-please`, `aidd-review`) — triage task added
- **Infrastructure files** (`index.md` files, `package.json`, `.gitignore`) — triage task added

### Design decisions documented
- `/aidd-parallel delegate` is the canonical delegate design (NOT standalone `/aidd-delegate` from PR #179)
- Only `/aidd-pipeline` from PR #179 is still needed
- One skill per PR rule enforced

### Updated full landing order
1. `/aidd-rtc` — split from PR #94
2. `/aidd-pipeline` — split from PR #179
3. `/aidd-parallel` (includes `delegate`) — split from PR #168
4. `/aidd-pr` — split from PR #168
5. Eval infrastructure — split from PR #168
6. `/aidd-upskill` — split from PR #94
7. `/aidd-genesplice` — PR #181 + PR #184
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-969ede41-22b3-4ad0-afb7-9eda0937d572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-969ede41-22b3-4ad0-afb7-9eda0937d572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

