### PR TITLE
feat(skills): add /aidd-upskill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ core.*
 # Local AIDD database
 .aidd/
 
+# Compiled validate-skill binary (built via npm run build:validate-skill)
+ai/skills/aidd-upskill/scripts/validate-skill
+

--- a/ai-evals/aidd-upskill/caveman-test.sudo
+++ b/ai-evals/aidd-upskill/caveman-test.sudo
@@ -1,0 +1,18 @@
+# caveman-test.sudo
+
+import 'ai/skills/aidd-upskill/SKILL.md'
+
+userPrompt = """
+Use caveman() to evaluate this skill design decision:
+
+A skill is being designed to both fetch external API data AND format the response
+into a markdown report. Should these two responsibilities live in a single skill
+command, or be split into two separate commands?
+"""
+
+- Given the caveman() function is invoked, should produce a 🎯 restate stage that restates the problem in plain terms (e.g. one command vs two commands, fetch + format responsibilities)
+- Given the caveman() function is invoked, should produce a 💡 ideate stage that generates at least two distinct design options (e.g. single combined command, split into fetch and format commands)
+- Given the caveman() function is invoked, should produce a 🪞 reflect stage that critically identifies a flaw in the ideation — such as noting that mixing a side effect (fetch) with a thinking stage (format) violates the "never mix thinking and effects" constraint from the skill
+- Given the caveman() function is invoked, should produce a 🔭 expand stage that explores orthogonal considerations not yet covered (e.g. testability, composability, progressive disclosure)
+- Given the caveman() function is invoked, should produce a ⚖️ score stage that ranks or evaluates the options against explicit criteria
+- Given the caveman() function is invoked, should produce a 💬 respond stage with a concrete recommendation

--- a/ai-evals/aidd-upskill/dedup-test.sudo
+++ b/ai-evals/aidd-upskill/dedup-test.sudo
@@ -1,0 +1,17 @@
+# dedup-test.sudo
+
+import 'ai/skills/aidd-upskill/SKILL.md'
+
+userPrompt = """
+Run deduplicateWithCaveman() on the following two files:
+
+SKILL.md body: ai-evals/aidd-upskill/fixtures/dedup-skill.md
+Reference file: ai-evals/aidd-upskill/fixtures/dedup-reference.md
+
+Identify every piece of information that appears in both files and determine
+where the single source of truth should live.
+"""
+
+- Given the SkillName constraints (lowercase alphanumeric, 1-64 chars, aidd- prefix, match parent dir) appear in both dedup-skill.md and dedup-reference.md, should identify the name constraint rules as duplicated information present in both files
+- Given the name constraints are duplicated, should identify the reference file (dedup-reference.md) as the canonical location because it is titled "Name Constraints" and explicitly notes it is the canonical definition
+- Given the name constraints are in the reference file, should recommend removing the duplicated name constraint prose from the SKILL.md body and relying solely on the import of the reference file

--- a/ai-evals/aidd-upskill/fixtures/dedup-reference.md
+++ b/ai-evals/aidd-upskill/fixtures/dedup-reference.md
@@ -1,0 +1,10 @@
+# Name Constraints
+
+The `name` field in a SKILL.md frontmatter must be:
+
+- lowercase alphanumeric with hyphens
+- 1-64 characters
+- prefixed with `aidd-`
+- must match the parent directory name
+
+This is the canonical definition of `SkillName` constraints.

--- a/ai-evals/aidd-upskill/fixtures/dedup-skill.md
+++ b/ai-evals/aidd-upskill/fixtures/dedup-skill.md
@@ -1,0 +1,24 @@
+---
+name: aidd-example-dedup
+description: Example skill used to test deduplication detection. Use when running dedup eval tests.
+---
+
+# aidd-example-dedup
+
+## Skill Structure
+
+Skills follow this directory layout:
+
+```
+ai/skills/aidd-<verbOrRoleBasedNoun>/
+├── SKILL.md          # Required: frontmatter + instructions
+├── scripts/          # Optional: CLI tools
+├── references/       # Optional: detailed reference docs
+└── assets/           # Optional: templates, data files
+```
+
+Frontmatter must include `name` and `description`. The `name` field must be
+lowercase alphanumeric with hyphens, 1-64 characters, prefixed with `aidd-`,
+and must match the parent directory name.
+
+import ai-evals/aidd-upskill/fixtures/dedup-reference.md

--- a/ai-evals/aidd-upskill/fixtures/sample-format-skill.md
+++ b/ai-evals/aidd-upskill/fixtures/sample-format-skill.md
@@ -1,0 +1,30 @@
+---
+name: aidd-format-changelog
+description: Format a list of git commits into a structured markdown changelog. Use when generating release notes or changelogs from commit history.
+---
+
+# aidd-format-changelog
+
+Given a list of raw git commit messages, produce a markdown changelog grouped
+by conventional commit type (feat, fix, chore, etc.) with each entry on its
+own line.
+
+## Steps
+
+1. Parse each commit message to extract type, scope, and description.
+2. Group entries by type.
+3. Render the grouped entries as a markdown changelog.
+
+## Example
+
+Input: `["feat(auth): add OAuth login", "fix(api): handle 429 rate limit"]`
+
+Output:
+
+```md
+## Features
+- **auth**: add OAuth login
+
+## Bug Fixes
+- **api**: handle 429 rate limit
+```

--- a/ai-evals/aidd-upskill/function-test.sudo
+++ b/ai-evals/aidd-upskill/function-test.sudo
@@ -1,0 +1,21 @@
+# function-test.sudo
+
+import 'ai/skills/aidd-upskill/SKILL.md'
+
+userPrompt = """
+Run the Function Test on the skill described in
+ai-evals/aidd-upskill/fixtures/sample-format-skill.md.
+
+Answer all five Function Test questions:
+1. What is f? Name it.
+2. What varies? (parameters)
+3. What is constant? (defaults)
+4. Is f deterministic?
+5. Is the result independently useful and recomposable?
+"""
+
+- Given the skill description maps raw git commits to a structured markdown changelog, should name f as something like "formatChangelog" or "groupCommitsByType" — a clear verb-based name
+- Given the skill accepts a list of commit messages as input, should identify the commit list as the parameter (what varies per caller)
+- Given every caller uses the same grouping logic and markdown rendering, should identify the grouping strategy and output format as defaults (what is constant)
+- Given the formatting logic is rule-based and produces the same output for the same input, should conclude that f is deterministic and therefore better suited to a CLI tool than an AI prompt
+- Given a deterministic f verdict, should state the result in terms of the CLI vs AI prompt constraint from the skill (i.e. deterministic logic => CLI tool or compiled Bun bundle)

--- a/ai/commands/aidd-upskill.md
+++ b/ai/commands/aidd-upskill.md
@@ -1,0 +1,13 @@
+## 🛠️ Upskill — Create or Review Skills
+
+Use `ai/skills/aidd-upskill/SKILL.md` to create a new agent skill following the AgentSkills.io specification.
+
+Constraints {
+  Before beginning, read and respect the constraints in ai/skills/aidd-please/SKILL.md.
+}
+
+## 🔍 Review Skill
+
+Use `ai/skills/aidd-upskill/SKILL.md` to review an existing skill against the quality criteria in this guide.
+
+Run: `/aidd-upskill review [path-to-skill]`

--- a/ai/commands/aidd-upskill.md
+++ b/ai/commands/aidd-upskill.md
@@ -1,13 +1,15 @@
-## 🛠️ Upskill — Create or Review Skills
+# 🛠️ /aidd-upskill
 
-Use `ai/skills/aidd-upskill/SKILL.md` to create a new agent skill following the AgentSkills.io specification.
+Load and execute the skill at `ai/skills/aidd-upskill/SKILL.md`.
 
 Constraints {
-  Before beginning, read and respect the constraints in ai/skills/aidd-please/SKILL.md.
+  Before beginning, read and respect the constraints in /aidd-please.
 }
 
-## 🔍 Review Skill
+## Create
 
-Use `ai/skills/aidd-upskill/SKILL.md` to review an existing skill against the quality criteria in this guide.
+Run: `/aidd-upskill create [name]`
+
+## Review
 
 Run: `/aidd-upskill review [path-to-skill]`

--- a/ai/commands/aidd-upskill.md
+++ b/ai/commands/aidd-upskill.md
@@ -1,3 +1,7 @@
+---
+description: Create and review AIDD skills following the AgentSkills.io specification and SudoLang authoring patterns.
+---
+
 # 🛠️ /aidd-upskill
 
 Load and execute the skill at `ai/skills/aidd-upskill/SKILL.md`.

--- a/ai/commands/index.md
+++ b/ai/commands/index.md
@@ -52,6 +52,12 @@ Write correct riteway ai prompt evals for multi-step tool-calling flows. Use whe
 
 *No description available*
 
+### 🛠️ /aidd-upskill
+
+**File:** `aidd-upskill.md`
+
+Create and review AIDD skills following the AgentSkills.io specification and SudoLang authoring patterns.
+
 ### Commit
 
 **File:** `commit.md`

--- a/ai/skills/aidd-agent-orchestrator/SKILL.md
+++ b/ai/skills/aidd-agent-orchestrator/SKILL.md
@@ -24,6 +24,7 @@ Agents {
   javascript-io-effects: when you need to make network requests or invoke side-effects, use this guide for saga pattern implementation
   ui: when building user interfaces and user experiences, use this guide for beautiful and friendly UI/UX design
   requirements: when writing functional requirements for a user story, use this guide for functional requirement specification
+  aidd-upskill: when creating a new agent skill, use this guide for AgentSkills.io specification and SudoLang skill authoring
 }
 
 const taskPrompt = "# Guides\n\nRead each of the following guides for important context, and follow their instructions carefully: ${list guide file refs in markdown format}\n\n# User Prompt\n\n${prompt}"

--- a/ai/skills/aidd-please/SKILL.md
+++ b/ai/skills/aidd-please/SKILL.md
@@ -45,6 +45,7 @@ Commands {
   📊 /aidd-churn - rank files by hotspot score (LoC × churn × complexity) to identify prime candidates for refactoring
   🧪 /user-test - use /aidd-user-testing to generate human and AI agent test scripts from user journeys
   🤖 /run-test - execute AI agent test script in real browser with screenshots
+  🛠️ /aidd-upskill - create a new agent skill using AgentSkills.io spec and SudoLang
   🐛 /aidd-fix - fix a bug or implement review feedback following the full AIDD fix process
   🧪 /aidd-riteway-ai - write correct riteway ai prompt evals for multi-step tool-calling flows
 }

--- a/ai/skills/aidd-upskill/README.md
+++ b/ai/skills/aidd-upskill/README.md
@@ -1,0 +1,34 @@
+# aidd-upskill
+
+Creates and reviews AIDD skills — the reusable instruction modules that guide
+agent behavior across a project.
+
+## Why
+
+Skills written without a clear structure accumulate bloat, mix concerns, and
+become hard to maintain. `aidd-upskill` applies a consistent authoring
+standard: each skill is a named function with defined inputs and outputs,
+sized to stay concise, and organized for progressive disclosure.
+
+## Commands
+
+```
+/aidd-upskill create [name]
+```
+
+Scaffolds a new skill at `aidd-custom/skills/aidd-[name]/SKILL.md` with the required
+frontmatter, sections, and directory layout.
+
+```
+/aidd-upskill review [target]
+```
+
+Evaluates an existing skill against authoring criteria: function test,
+required sections, size thresholds, command separation, and README quality.
+Reports issues and a pass/fail verdict.
+
+## When to use
+
+- Creating a new skill from scratch in `ai/skills/` or `aidd-custom/skills/`
+- Reviewing or refactoring an existing skill for quality and consistency
+- Checking whether a candidate abstraction is ready to become a named skill

--- a/ai/skills/aidd-upskill/SKILL.md
+++ b/ai/skills/aidd-upskill/SKILL.md
@@ -9,7 +9,7 @@ description: Guide for crafting high-quality AIDD skills. Use when creating, rev
 
 Expert skill author. Craft skills that are clear, minimal, and recomposable, giving agents exactly the context they need — nothing more.
 
-**Skill components:** `ai/skills/aidd-sudolang-syntax`, `ai/skills/aidd-rtc`
+**Skill components:** `ai/skills/aidd-sudolang-syntax`, `ai/skills/aidd-please` (provides RTC think())
 
 Constraints {
   Prefer natural language in markdown format

--- a/ai/skills/aidd-upskill/SKILL.md
+++ b/ai/skills/aidd-upskill/SKILL.md
@@ -11,6 +11,8 @@ Expert skill author. Craft skills that are clear, minimal, and recomposable, giv
 
 **Skill components:** `ai/skills/aidd-sudolang-syntax`, `ai/skills/aidd-please` (provides RTC think())
 
+**SudoLang spec:** https://github.com/paralleldrive/sudolang/blob/main/sudolang.sudo.md — generated skills must follow SudoLang syntax.
+
 Constraints {
   Prefer natural language in markdown format
   Use SudoLang interfaces, pattern matching, and /commands for formal specification

--- a/ai/skills/aidd-upskill/SKILL.md
+++ b/ai/skills/aidd-upskill/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: aidd-upskill
+description: Guide for crafting high-quality AIDD skills. Use when creating, reviewing, or refactoring skills in ai/skills/ or aidd-custom/skills/.
+---
+
+# aidd-upskill
+
+## Role
+
+Expert skill author. Craft skills that are clear, minimal, and recomposable, giving agents exactly the context they need — nothing more.
+
+**Skill components:** `ai/skills/aidd-sudolang-syntax`, `ai/skills/aidd-rtc`
+
+Constraints {
+  Prefer natural language in markdown format
+  Use SudoLang interfaces, pattern matching, and /commands for formal specification
+  (logic is deterministic) => CLI tool or compiled Bun bundle
+  (logic requires judgment) => AI prompt
+  (a candidate abstraction cannot be named) => it is not an abstraction yet
+  (two or more skills share the same f) => extract a shared abstraction
+}
+
+Commands {
+  /aidd-upskill create [name] — scaffold a new skill at aidd-custom/skills/aidd-[name]/SKILL.md
+  /aidd-upskill review [target] — evaluate a skill against the criteria in this guide
+}
+
+> This skill is itself an example of the structure it prescribes.
+
+import references/types.md
+import references/process.md
+
+## Process
+
+The `createSkill` and `reviewSkill` pipelines — including all step definitions — are defined in
+`references/process.md` (imported above). Read that file for the full authoring and review
+workflows.
+
+---
+
+## Skill Structure
+
+```
+ai/skills/aidd-<verbOrRoleBasedNoun>/
+├── SKILL.md          # Required: frontmatter + instructions
+├── README.md         # Optional: what the skill is, why it's useful, command reference
+├── scripts/          # Optional: CLI tools
+├── references/       # Optional: detailed reference docs
+└── assets/           # Optional: templates, data files
+```
+
+## Progressive Disclosure
+
+1. `name` + `description` — loaded at startup for all skills
+2. Full `SKILL.md` body — loaded on activation
+3. `scripts/`, `references/`, `assets/` — loaded on demand
+
+Keep `SKILL.md` concise — run `validate-skill` to check thresholds. Move reference material to `references/`. Use `import $referenceFile` to link it.
+
+---
+
+## A Skill Is a Function
+
+```
+f: Input → Output
+```
+
+Every skill maps input context to output or action. Use this as the primary design lens.
+
+### Abstraction
+
+Two skills sharing the same `f` should share the same abstraction:
+
+- **Generalization:** extract the shared `f`, name it, hide it
+- **Specialization:** expose only what differs as parameters
+
+```
+f: A → B
+g: B → C
+h: A → C   ← h hides B. This is a good abstraction.
+```
+
+> "Simplicity is removing the obvious and adding the meaningful." — John Maeda
+
+### The Function Test
+
+1. What is `f`? Name it. If you can't name it, it's not an abstraction yet.
+2. What varies? Those are the parameters — expose them.
+3. What is constant? Those are the defaults — hide them.
+4. Is `f` deterministic? See CLI vs. AI prompt in Constraints above.
+5. Is the result independently useful and recomposable? If not, it's inlining, not abstraction.
+
+### Default Parameters
+
+Use defaults wherever the default is obvious. Callers supply only what is meaningfully different. If every caller passes the same value, it's a default waiting to be named.
+
+---
+
+## Eval Tests
+
+Use Riteway AI to write eval tests for skill commands. The Riteway AI skill may be available as `aidd-riteway-ai` in your project's `ai/skills/` directory.
+
+**Core principle:** never mix thinking and effects in a single `/command`. Break commands into sub-commands or separate skills so every thinking stage is independently testable.
+
+```
+(command involves thinking + side effects) => split into sub-commands
+(command is a pure thinking stage) => write an eval test
+(command is a side effect only) => skip the test
+```
+
+### Eval Test Structure
+
+Tests are `.sudo` files using SudoLang syntax:
+
+````
+# my-skill-test.sudo
+
+import 'path/to/skill.md'
+
+userPrompt = """
+<the prompt or command input being tested>
+"""
+
+- Given <context>, should <expected thinking output>
+- Given <context>, should <expected thinking output>
+````
+
+Run with:
+
+```shell
+riteway ai path/to/my-skill-test.sudo
+```
+
+Defaults: 4 passes, 75% pass rate threshold, claude agent.

--- a/ai/skills/aidd-upskill/index.md
+++ b/ai/skills/aidd-upskill/index.md
@@ -1,0 +1,22 @@
+# aidd-upskill
+
+This index provides an overview of the contents in this directory.
+
+## Subdirectories
+
+### 📁 references/
+
+See [`references/index.md`](./references/index.md) for contents.
+
+### 📁 scripts/
+
+See [`scripts/index.md`](./scripts/index.md) for contents.
+
+## Files
+
+### aidd-upskill
+
+**File:** `SKILL.md`
+
+Guide for crafting high-quality AIDD skills. Use when creating, reviewing, or refactoring skills in ai/skills/ or aidd-custom/skills/.
+

--- a/ai/skills/aidd-upskill/references/index.md
+++ b/ai/skills/aidd-upskill/references/index.md
@@ -1,0 +1,18 @@
+# references
+
+This index provides an overview of the contents in this directory.
+
+## Files
+
+### Skill Creation Process
+
+**File:** `process.md`
+
+*No description available*
+
+### Types & Interfaces
+
+**File:** `types.md`
+
+*No description available*
+

--- a/ai/skills/aidd-upskill/references/process.md
+++ b/ai/skills/aidd-upskill/references/process.md
@@ -6,7 +6,7 @@
 createSkill(userRequest) {
   gatherRequirements
     |> nameSkill
-    |> /aidd-rtc --compact
+    |> think() --compact
     |> buildPlan
     |> presentPlan
     |> draftSkillMd
@@ -78,7 +78,7 @@ reviewSkill(target) {
     |> checkCommandSeparation
     |> checkReadme
     |> deduplicate()
-    |> /aidd-rtc --compact
+    |> think() --compact
     |> reportFindings
 }
 ```
@@ -88,6 +88,6 @@ reviewSkill(target) {
 **checkSizeMetrics** — run `validate-skill` and report warnings  
 **checkCommandSeparation** — verify no command mixes thinking and side effects
 **checkReadme** — verify README.md exists and contains what/why/commands; flag if it contains implementation details or process narratives
-**deduplicate()** — find every instance of repeated information across SKILL.md and its references; flag each duplicate and identify where the single source of truth should live; use `/aidd-rtc --compact` to reason about the canonical location  
-**/aidd-rtc --compact** — synthesize all findings into a holistic judgment before rendering the verdict; independently testable as a pure thinking stage  
+**deduplicate()** — find every instance of repeated information across SKILL.md and its references; flag each duplicate and identify where the single source of truth should live; use `think() --compact` to reason about the canonical location  
+**think() --compact** — synthesize all findings into a holistic judgment before rendering the verdict (uses the RTC think() function from `aidd-please`); independently testable as a pure thinking stage  
 **reportFindings** — produce a per-check pass/fail table (one row per check: runFunctionTest, checkRequiredSections, checkSizeMetrics, checkCommandSeparation, checkReadme, deduplicate) with columns for check name, result (✅/⚠️/❌), and detail; conclude with an overall verdict

--- a/ai/skills/aidd-upskill/references/process.md
+++ b/ai/skills/aidd-upskill/references/process.md
@@ -1,0 +1,93 @@
+# Skill Creation Process
+
+## Pipeline
+
+```
+createSkill(userRequest) {
+  gatherRequirements
+    |> nameSkill
+    |> /aidd-rtc --compact
+    |> buildPlan
+    |> presentPlan
+    |> draftSkillMd
+    |> writeSkill
+    |> writeReadme
+    |> validate
+    |> reportMetrics
+}
+```
+
+## Steps
+
+**gatherRequirements(userRequest)**
+1. discoverRelatedSkills — search `$projectRoot/ai/` and `$projectRoot/aidd-custom/` for SKILL.md, `.mdc`, `.md` files; read frontmatter descriptions; identify overlap or complementary skills
+2. researchBestPractices — use web search to find best practices for the domain; summarize findings
+3. Infer requirements from the above context. Do not ask clarifying questions or block on user input. Use a judge to evaluate completeness: yes → proceed; no → state gaps as explicit assumptions and proceed.
+
+Infer answers to these questions from context rather than asking the user:
+- What problem does this skill solve?
+- What are its inputs and outputs?
+- Any technical constraints or requirements?
+- Should it `alwaysApply`? (recommend yes only if it applies to nearly every task)
+
+**nameSkill(topic)**
+- Use verb or role-based noun form (e.g., `aidd-format-code`, `aidd-upskill`)
+- Validate against `SkillName` type constraints
+
+**buildPlan() => SkillPlan**
+Produce a `SkillPlan` struct (see `references/types.md`).
+
+**presentPlan(plan: SkillPlan)**
+Show the full plan, then run a self-validating quality gate — do not await user approval:
+1. Run `/aidd-review` on the plan
+2. Issues found => run `/aidd-fix` loop until all issues are resolved
+3. Proceed to `draftSkillMd`
+
+**draftSkillMd(plan: SkillPlan)**
+- Write frontmatter: `name` + `description` required; add `metadata.alwaysApply` if needed
+- Write body with all `RequiredSections`
+- If body will exceed the line threshold (run `validate-skill` to check), extract content to `references/` and use `import $referenceFile`
+
+**writeSkill(skillMd)**
+- Write to `$projectRoot/aidd-custom/skills/${skillName}/SKILL.md`
+- Create `scripts/`, `references/`, or `assets/` directories only if planned
+
+**writeReadme(skillMd)**
+- Write `README.md` in the skill directory
+- Include: what the skill is, why it is useful, command reference with usage examples
+- Exclude: implementation details, process narratives, pipeline descriptions
+
+**validate**
+```bash
+ai/skills/aidd-upskill/scripts/validate-skill ./path-to-skill-directory
+# If skills-ref is available:
+skills-ref validate ./path-to-skill-directory
+```
+
+**reportMetrics**
+Report `SizeMetrics` and any threshold warnings to the user.
+
+## Skill Review Process
+
+```
+reviewSkill(target) {
+  readSkill(target)
+    |> runFunctionTest
+    |> checkRequiredSections
+    |> checkSizeMetrics
+    |> checkCommandSeparation
+    |> checkReadme
+    |> deduplicate()
+    |> /aidd-rtc --compact
+    |> reportFindings
+}
+```
+
+**runFunctionTest** — apply the 5-question Function Test from SKILL.md  
+**checkRequiredSections** — verify all `RequiredSections` are present  
+**checkSizeMetrics** — run `validate-skill` and report warnings  
+**checkCommandSeparation** — verify no command mixes thinking and side effects
+**checkReadme** — verify README.md exists and contains what/why/commands; flag if it contains implementation details or process narratives
+**deduplicate()** — find every instance of repeated information across SKILL.md and its references; flag each duplicate and identify where the single source of truth should live; use `/aidd-rtc --compact` to reason about the canonical location  
+**/aidd-rtc --compact** — synthesize all findings into a holistic judgment before rendering the verdict; independently testable as a pure thinking stage  
+**reportFindings** — produce a per-check pass/fail table (one row per check: runFunctionTest, checkRequiredSections, checkSizeMetrics, checkCommandSeparation, checkReadme, deduplicate) with columns for check name, result (✅/⚠️/❌), and detail; conclude with an overall verdict

--- a/ai/skills/aidd-upskill/references/types.md
+++ b/ai/skills/aidd-upskill/references/types.md
@@ -1,0 +1,75 @@
+# Types & Interfaces
+
+## Types
+
+```
+type SkillName = string(
+  1-64 chars,
+  lowercase alphanumeric + hyphens,
+  no leading/trailing/consecutive hyphens,
+  must match parent directory name,
+  prefix: "aidd-",
+  verb or role-based noun
+)
+
+type SkillDescription = string(
+  1-1024 chars,
+  describes what the skill does AND when to use it,
+  precise enough for an agent to activate on description alone
+)
+```
+
+## SizeMetrics
+
+```
+SizeMetrics {
+  frontmatterTokens: number  // run validate-skill for current thresholds
+  bodyLines: number          // run validate-skill for current thresholds
+  bodyTokens: number         // run validate-skill for current thresholds
+}
+```
+
+## SkillPlan
+
+```
+SkillPlan {
+  name: SkillName
+  purpose: SkillDescription
+  alwaysApply: boolean       // preload on project init? Use sparingly.
+  relatedSkills[]            // existing skills found during discovery
+  bestPractices[]            // findings from research
+  proposedSections[]         // planned SKILL.md structure
+  optionalDirs: ["scripts" | "references" | "assets"]
+  sizeEstimate: SizeMetrics
+}
+```
+
+## Frontmatter
+
+```
+Frontmatter {
+  name: SkillName                       // required
+  description: SkillDescription         // required
+  license                               // optional
+  compatibility: string(1-500)          // optional, environment requirements
+  metadata {}                           // optional, AIDD extensions
+  allowed-tools                         // optional, space-delimited tool list
+}
+```
+
+### AIDD Extensions via `metadata`
+
+`metadata.alwaysApply: "true"` preloads the full SKILL.md on project init.
+Use only for skills that apply to nearly every task (e.g., coding standards).
+Task-specific skills should activate on demand, not preload.
+
+## RequiredSections
+
+Every generated SKILL.md body must include:
+
+```
+RequiredSections {
+  "# Title"                  // skill name as heading
+  "## Steps" | "## Process"  // ordered execution instructions
+}
+```

--- a/ai/skills/aidd-upskill/scripts/index.md
+++ b/ai/skills/aidd-upskill/scripts/index.md
@@ -1,0 +1,8 @@
+# scripts
+
+This index provides an overview of the contents in this directory.
+
+| File | Description |
+|------|-------------|
+| `validate-skill.js` | Validator module and CLI entry point — checks a skill directory for name validity, frontmatter structure, and size thresholds |
+| `validate-skill.test.js` | Unit tests for the validator |

--- a/ai/skills/aidd-upskill/scripts/validate-skill.js
+++ b/ai/skills/aidd-upskill/scripts/validate-skill.js
@@ -1,0 +1,170 @@
+/**
+ * Validate an AgentSkills.io SKILL.md file.
+ *
+ * Usage: validate-skill ./path-to-skill-directory
+ *        (compiled to a binary via `bun build --compile`)
+ *        For development: bun run validate-skill.js ./path-to-skill-directory
+ */
+
+import { readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { fileURLToPath } from "url";
+import yaml from "js-yaml";
+
+export const parseSkillMd = (content) => {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return { body: content, frontmatter: "" };
+  return {
+    body: content.slice(match[0].length).trim(),
+    frontmatter: match[1],
+  };
+};
+
+export const validateName = (name, dirName) => {
+  const errors = [];
+  if (name.length < 1 || name.length > 64)
+    errors.push("Name must be 1-64 characters");
+  if (/[^a-z0-9-]/.test(name))
+    errors.push("Name must be lowercase alphanumeric + hyphens only");
+  if (!name.startsWith("aidd-"))
+    errors.push("Name must start with 'aidd-' prefix");
+  if (/^-|-$/.test(name)) errors.push("Name must not start or end with hyphen");
+  if (/--/.test(name)) errors.push("Name must not contain consecutive hyphens");
+  if (name !== dirName) errors.push("Name must match directory name");
+  return errors;
+};
+
+export const calculateMetrics = (frontmatter, body) => ({
+  bodyLines: body.split("\n").length,
+  bodyTokens: Math.ceil(body.length / 4),
+  frontmatterTokens: Math.ceil(frontmatter.length / 4),
+});
+
+const ALLOWED_FRONTMATTER_KEYS = new Set([
+  "name",
+  "description",
+  "license",
+  "compatibility",
+  "metadata",
+  "allowed-tools",
+]);
+
+export const validateFrontmatterKeys = (frontmatterObj) => {
+  const errors = [];
+  for (const key of Object.keys(frontmatterObj)) {
+    if (!ALLOWED_FRONTMATTER_KEYS.has(key)) {
+      errors.push(`Unknown frontmatter key: ${key}`);
+    }
+  }
+  return errors;
+};
+
+export const checkThresholds = (metrics) => {
+  const errors = [];
+  const warnings = [];
+  if (metrics.frontmatterTokens >= 100)
+    warnings.push("Frontmatter reaches or exceeds 100 token guideline");
+  if (metrics.bodyLines >= 500)
+    errors.push(
+      "Body exceeds 500 line spec limit - split into reference files",
+    );
+  else if (metrics.bodyLines >= 160)
+    warnings.push("Body exceeds 160 line guideline");
+  if (metrics.bodyTokens >= 5000)
+    warnings.push("Body exceeds 5000 token spec guideline");
+  return { errors, warnings };
+};
+
+/**
+ * Parse and validate SKILL.md content against a known directory name.
+ * Returns { errors, warnings, metrics }.
+ */
+export const validateSkillContent = (content, dirName) => {
+  const { frontmatter, body } = parseSkillMd(content);
+  const errors = [];
+  let parsedFrontmatter;
+  try {
+    parsedFrontmatter = frontmatter ? yaml.load(frontmatter) : {};
+  } catch (e) {
+    errors.push(`Invalid YAML in frontmatter: ${e.message}`);
+    const metrics = calculateMetrics(frontmatter, body);
+    const { errors: thresholdErrors, warnings } = checkThresholds(metrics);
+    return { errors: [...errors, ...thresholdErrors], metrics, warnings };
+  }
+  if (
+    typeof parsedFrontmatter !== "object" ||
+    parsedFrontmatter === null ||
+    Array.isArray(parsedFrontmatter)
+  ) {
+    errors.push("Frontmatter must be a YAML mapping (key-value object)");
+    const metrics = calculateMetrics(frontmatter, body);
+    const { errors: thresholdErrors, warnings } = checkThresholds(metrics);
+    return { errors: [...errors, ...thresholdErrors], metrics, warnings };
+  }
+  const name =
+    typeof parsedFrontmatter.name === "string" ? parsedFrontmatter.name : "";
+  const description =
+    typeof parsedFrontmatter.description === "string"
+      ? parsedFrontmatter.description
+      : "";
+  errors.push(...validateName(name, dirName));
+  errors.push(...validateFrontmatterKeys(parsedFrontmatter));
+  if (!description) errors.push("Description is required");
+  else if (description.length > 1024)
+    errors.push("Description must be 1024 characters or fewer");
+  const metrics = calculateMetrics(frontmatter, body);
+  const { errors: thresholdErrors, warnings } = checkThresholds(metrics);
+  return { errors: [...errors, ...thresholdErrors], metrics, warnings };
+};
+
+/** Resolves whether this module is the entry point (testable; mirrors CLI guard). */
+export const resolveIsMainEntry = ({ main, argv1, moduleUrl }) =>
+  typeof main !== "undefined" ? main : argv1 === fileURLToPath(moduleUrl);
+
+const isMain = resolveIsMainEntry({
+  argv1: process.argv[1],
+  main: import.meta.main,
+  moduleUrl: import.meta.url,
+});
+
+if (isMain) {
+  const skillDir = process.argv[2];
+  if (!skillDir) {
+    console.error("Usage: validate-skill <path-to-skill-directory>");
+    process.exit(1);
+  }
+
+  const dirName = basename(skillDir);
+  let content;
+  try {
+    content = readFileSync(join(skillDir, "SKILL.md"), "utf8");
+  } catch {
+    console.error(`Error: could not read SKILL.md in ${skillDir}`);
+    process.exit(1);
+  }
+
+  const { errors, metrics, warnings } = validateSkillContent(content, dirName);
+
+  console.log(`\nValidating: ${skillDir}\n`);
+  console.log("Metrics:");
+  console.log(`  frontmatterTokens : ${metrics.frontmatterTokens}`);
+  console.log(`  bodyLines         : ${metrics.bodyLines}`);
+  console.log(`  bodyTokens        : ${metrics.bodyTokens}`);
+
+  if (warnings.length > 0) {
+    console.log("\nWarnings:");
+    for (const w of warnings) console.log(`  ⚠  ${w}`);
+  }
+
+  if (errors.length > 0) {
+    console.log("\nErrors:");
+    for (const e of errors) console.log(`  ✖  ${e}`);
+    process.exit(1);
+  }
+
+  console.log(
+    warnings.length > 0
+      ? "\n⚠  Validation passed with warnings."
+      : "\n✔  Validation passed.",
+  );
+}

--- a/ai/skills/aidd-upskill/scripts/validate-skill.js
+++ b/ai/skills/aidd-upskill/scripts/validate-skill.js
@@ -34,6 +34,8 @@ export const validateName = (name, dirName) => {
   return errors;
 };
 
+// Token counts are rough estimates (chars / 4). This is a heuristic, not a
+// real tokenizer — actual counts may vary by 30-50% depending on content.
 export const calculateMetrics = (frontmatter, body) => ({
   bodyLines: body.split("\n").length,
   bodyTokens: Math.ceil(body.length / 4),
@@ -84,7 +86,9 @@ export const validateSkillContent = (content, dirName) => {
   const errors = [];
   let parsedFrontmatter;
   try {
-    parsedFrontmatter = frontmatter ? yaml.load(frontmatter) : {};
+    parsedFrontmatter = frontmatter
+      ? yaml.load(frontmatter, { schema: yaml.DEFAULT_SAFE_SCHEMA })
+      : {};
   } catch (e) {
     errors.push(`Invalid YAML in frontmatter: ${e.message}`);
     const metrics = calculateMetrics(frontmatter, body);
@@ -112,6 +116,9 @@ export const validateSkillContent = (content, dirName) => {
   if (!description) errors.push("Description is required");
   else if (description.length > 1024)
     errors.push("Description must be 1024 characters or fewer");
+  if (!/^# .+/m.test(body)) errors.push("Body must contain a top-level heading (# Title)");
+  if (!/^## (?:Steps|Process)/m.test(body))
+    errors.push("Body must contain a ## Steps or ## Process section");
   const metrics = calculateMetrics(frontmatter, body);
   const { errors: thresholdErrors, warnings } = checkThresholds(metrics);
   return { errors: [...errors, ...thresholdErrors], metrics, warnings };

--- a/ai/skills/aidd-upskill/scripts/validate-skill.js
+++ b/ai/skills/aidd-upskill/scripts/validate-skill.js
@@ -116,7 +116,8 @@ export const validateSkillContent = (content, dirName) => {
   if (!description) errors.push("Description is required");
   else if (description.length > 1024)
     errors.push("Description must be 1024 characters or fewer");
-  if (!/^# .+/m.test(body)) errors.push("Body must contain a top-level heading (# Title)");
+  if (!/^# .+/m.test(body))
+    errors.push("Body must contain a top-level heading (# Title)");
   if (!/^## (?:Steps|Process)/m.test(body))
     errors.push("Body must contain a ## Steps or ## Process section");
   const metrics = calculateMetrics(frontmatter, body);

--- a/ai/skills/aidd-upskill/scripts/validate-skill.test.js
+++ b/ai/skills/aidd-upskill/scripts/validate-skill.test.js
@@ -1,0 +1,867 @@
+import { fileURLToPath } from "url";
+import { assert } from "riteway/vitest";
+import { describe, test } from "vitest";
+
+import {
+  calculateMetrics,
+  checkThresholds,
+  parseSkillMd,
+  resolveIsMainEntry,
+  validateFrontmatterKeys,
+  validateName,
+  validateSkillContent,
+} from "./validate-skill.js";
+
+describe("resolveIsMainEntry", () => {
+  const moduleUrl =
+    "file:///workspace/ai/skills/aidd-upskill/scripts/validate-skill.js";
+  const modulePath = fileURLToPath(moduleUrl);
+
+  test("uses import.meta.main when defined (Bun)", () => {
+    assert({
+      given: "import.meta.main is true and argv1 does not match module path",
+      should: "return true so compiled Bun binaries still run the CLI",
+      actual: resolveIsMainEntry({
+        main: true,
+        argv1: "/tmp/stale-build-path",
+        moduleUrl,
+      }),
+      expected: true,
+    });
+
+    assert({
+      given: "import.meta.main is false",
+      should: "return false",
+      actual: resolveIsMainEntry({
+        main: false,
+        argv1: modulePath,
+        moduleUrl,
+      }),
+      expected: false,
+    });
+  });
+
+  test("falls back to argv comparison when main is undefined (Node)", () => {
+    assert({
+      given: "main is undefined and argv1 matches this module URL path",
+      should: "return true",
+      actual: resolveIsMainEntry({
+        main: undefined,
+        argv1: modulePath,
+        moduleUrl,
+      }),
+      expected: true,
+    });
+
+    assert({
+      given: "main is undefined and argv1 does not match",
+      should: "return false",
+      actual: resolveIsMainEntry({
+        main: undefined,
+        argv1: "/other/script.js",
+        moduleUrl,
+      }),
+      expected: false,
+    });
+  });
+});
+
+describe("parseSkillMd", () => {
+  test("valid frontmatter", () => {
+    const content = `---
+name: my-skill
+description: A test skill.
+---
+# My Skill
+
+Body content here.`;
+
+    const result = parseSkillMd(content);
+
+    assert({
+      given: "SKILL.md content with valid frontmatter",
+      should: "return parsed frontmatter string",
+      actual: result.frontmatter,
+      expected: "name: my-skill\ndescription: A test skill.",
+    });
+
+    assert({
+      given: "SKILL.md content with valid frontmatter",
+      should: "return body without frontmatter",
+      actual: result.body,
+      expected: "# My Skill\n\nBody content here.",
+    });
+  });
+
+  test("no frontmatter", () => {
+    const content = "# Just a body\n\nNo frontmatter here.";
+    const result = parseSkillMd(content);
+
+    assert({
+      given: "content without frontmatter",
+      should: "return empty frontmatter",
+      actual: result.frontmatter,
+      expected: "",
+    });
+
+    assert({
+      given: "content without frontmatter",
+      should: "return full content as body",
+      actual: result.body,
+      expected: content,
+    });
+  });
+
+  test("CRLF line endings", () => {
+    const content =
+      "---\r\nname: aidd-my-skill\r\ndescription: A test skill.\r\n---\r\n# My Skill\r\n\r\nBody content here.";
+    const result = parseSkillMd(content);
+
+    assert({
+      given: "SKILL.md content with CRLF line endings",
+      should: "return parsed frontmatter string",
+      actual: result.frontmatter,
+      expected: "name: aidd-my-skill\r\ndescription: A test skill.",
+    });
+
+    assert({
+      given: "SKILL.md content with CRLF line endings",
+      should: "return body without frontmatter block",
+      actual: result.body,
+      expected: "# My Skill\r\n\r\nBody content here.",
+    });
+  });
+});
+
+describe("validateName", () => {
+  test("valid names", () => {
+    assert({
+      given: "a valid aidd-prefixed lowercase hyphenated name",
+      should: "return no errors",
+      actual: validateName("aidd-format-code", "aidd-format-code"),
+      expected: [],
+    });
+  });
+
+  test("missing aidd- prefix", () => {
+    const errors = validateName("format-code", "format-code");
+
+    assert({
+      given: "a name without the aidd- prefix",
+      should: "return an error requiring the aidd- prefix",
+      actual: errors[0],
+      expected: "Name must start with 'aidd-' prefix",
+    });
+  });
+
+  test("uppercase letters", () => {
+    const errors = validateName("Format-Code", "Format-Code");
+
+    assert({
+      given: "a name with uppercase letters",
+      should: "return an error requiring lowercase alphanumeric + hyphens",
+      actual: errors[0],
+      expected: "Name must be lowercase alphanumeric + hyphens only",
+    });
+
+    assert({
+      given: "a name with uppercase letters",
+      should: "also return an error requiring the aidd- prefix",
+      actual: errors[1],
+      expected: "Name must start with 'aidd-' prefix",
+    });
+  });
+
+  test("leading hyphen", () => {
+    const errors = validateName("-my-skill", "-my-skill");
+
+    assert({
+      given: "a name starting with a hyphen",
+      should: "return an error requiring the aidd- prefix",
+      actual: errors[0],
+      expected: "Name must start with 'aidd-' prefix",
+    });
+
+    assert({
+      given: "a name starting with a hyphen",
+      should: "return an error about leading/trailing hyphen",
+      actual: errors[1],
+      expected: "Name must not start or end with hyphen",
+    });
+  });
+
+  test("trailing hyphen", () => {
+    const errors = validateName("my-skill-", "my-skill-");
+
+    assert({
+      given: "a name ending with a hyphen",
+      should: "return an error requiring the aidd- prefix",
+      actual: errors[0],
+      expected: "Name must start with 'aidd-' prefix",
+    });
+
+    assert({
+      given: "a name ending with a hyphen",
+      should: "return an error about leading/trailing hyphen",
+      actual: errors[1],
+      expected: "Name must not start or end with hyphen",
+    });
+  });
+
+  test("consecutive hyphens", () => {
+    const errors = validateName("my--skill", "my--skill");
+
+    assert({
+      given: "a name with consecutive hyphens",
+      should: "return an error requiring the aidd- prefix",
+      actual: errors[0],
+      expected: "Name must start with 'aidd-' prefix",
+    });
+
+    assert({
+      given: "a name with consecutive hyphens",
+      should: "return an error about consecutive hyphens",
+      actual: errors[1],
+      expected: "Name must not contain consecutive hyphens",
+    });
+  });
+
+  test("too long", () => {
+    const longName = "a".repeat(65);
+    const errors = validateName(longName, longName);
+
+    assert({
+      given: "a name longer than 64 characters",
+      should: "return an error about name length",
+      actual: errors[0],
+      expected: "Name must be 1-64 characters",
+    });
+
+    assert({
+      given: "a name longer than 64 characters",
+      should: "return an error requiring the aidd- prefix",
+      actual: errors[1],
+      expected: "Name must start with 'aidd-' prefix",
+    });
+  });
+
+  test("empty name", () => {
+    const errors = validateName("", "some-dir");
+
+    assert({
+      given: "an empty name",
+      should: "return an error about name length",
+      actual: errors[0],
+      expected: "Name must be 1-64 characters",
+    });
+
+    assert({
+      given: "an empty name",
+      should: "return an error requiring the aidd- prefix",
+      actual: errors[1],
+      expected: "Name must start with 'aidd-' prefix",
+    });
+
+    assert({
+      given: "an empty name",
+      should: "return an error about mismatched directory name",
+      actual: errors[2],
+      expected: "Name must match directory name",
+    });
+  });
+
+  test("directory mismatch", () => {
+    const errors = validateName("my-skill", "other-dir");
+
+    assert({
+      given: "a name that does not match the directory name",
+      should: "return an error requiring the aidd- prefix",
+      actual: errors[0],
+      expected: "Name must start with 'aidd-' prefix",
+    });
+
+    assert({
+      given: "a name that does not match the directory name",
+      should: "return an error about mismatched directory name",
+      actual: errors[1],
+      expected: "Name must match directory name",
+    });
+  });
+});
+
+describe("calculateMetrics", () => {
+  test("calculates correct metrics", () => {
+    const frontmatter = "name: test\ndescription: A test.";
+    const body = "# Title\n\nLine 2\nLine 3";
+    const result = calculateMetrics(frontmatter, body);
+
+    assert({
+      given: "frontmatter and body text",
+      should: "estimate frontmatter tokens as ceil(31 chars / 4) = 8",
+      actual: result.frontmatterTokens,
+      expected: 8,
+    });
+
+    assert({
+      given: "a body with 4 lines",
+      should: "count 4 body lines",
+      actual: result.bodyLines,
+      expected: 4,
+    });
+
+    assert({
+      given: "body text",
+      should: "estimate body tokens as ceil(22 chars / 4) = 6",
+      actual: result.bodyTokens,
+      expected: 6,
+    });
+  });
+});
+
+describe("checkThresholds", () => {
+  test("all within limits", () => {
+    const metrics = { frontmatterTokens: 50, bodyLines: 100, bodyTokens: 3000 };
+    const result = checkThresholds(metrics);
+
+    assert({
+      given: "metrics within all thresholds",
+      should: "return no errors",
+      actual: result.errors,
+      expected: [],
+    });
+
+    assert({
+      given: "metrics within all thresholds",
+      should: "return no warnings",
+      actual: result.warnings,
+      expected: [],
+    });
+  });
+
+  test("frontmatter too large", () => {
+    const metrics = { frontmatterTokens: 100, bodyLines: 50, bodyTokens: 1000 };
+    const result = checkThresholds(metrics);
+
+    assert({
+      given: "frontmatter at 100 tokens",
+      should: "return a frontmatter warning",
+      actual: result.warnings.some((w) => w.includes("Frontmatter")),
+      expected: true,
+    });
+
+    assert({
+      given: "frontmatter at 100 tokens",
+      should: "not produce a hard error",
+      actual: result.errors,
+      expected: [],
+    });
+  });
+
+  test("body exceeds 160 lines", () => {
+    const metrics = { frontmatterTokens: 10, bodyLines: 160, bodyTokens: 1000 };
+    const result = checkThresholds(metrics);
+
+    assert({
+      given: "body at 160 lines",
+      should: "return a 160-line warning",
+      actual: result.warnings.some((w) => w.includes("160")),
+      expected: true,
+    });
+
+    assert({
+      given: "body at 160 lines",
+      should: "not produce a hard error",
+      actual: result.errors,
+      expected: [],
+    });
+  });
+
+  test("body exceeds 500 lines", () => {
+    const metrics = { frontmatterTokens: 10, bodyLines: 500, bodyTokens: 1000 };
+    const result = checkThresholds(metrics);
+
+    assert({
+      given: "body at 500 lines",
+      should: "return a 500-line hard error",
+      actual: result.errors.some((e) => e.includes("500")),
+      expected: true,
+    });
+
+    assert({
+      given: "body at 500 lines",
+      should: "not duplicate 500-line message in warnings",
+      actual: result.warnings.some((w) => w.includes("500")),
+      expected: false,
+    });
+  });
+
+  test("body exceeds 5000 tokens", () => {
+    const metrics = { frontmatterTokens: 10, bodyLines: 50, bodyTokens: 5000 };
+    const result = checkThresholds(metrics);
+
+    assert({
+      given: "body at 5000 tokens",
+      should: "return a token warning",
+      actual: result.warnings.some((w) => w.includes("5000")),
+      expected: true,
+    });
+
+    assert({
+      given: "body at 5000 tokens",
+      should: "not produce a hard error",
+      actual: result.errors,
+      expected: [],
+    });
+  });
+
+  test("body at 159 lines (just below soft threshold)", () => {
+    const metrics = { frontmatterTokens: 10, bodyLines: 159, bodyTokens: 1000 };
+    const result = checkThresholds(metrics);
+
+    assert({
+      given: "body at 159 lines",
+      should: "return no body-line warning",
+      actual: result.warnings.filter((w) => w.includes("160")),
+      expected: [],
+    });
+
+    assert({
+      given: "body at 159 lines",
+      should: "return no errors",
+      actual: result.errors,
+      expected: [],
+    });
+  });
+
+  test("body at 499 lines (just below hard limit)", () => {
+    const metrics = { frontmatterTokens: 10, bodyLines: 499, bodyTokens: 1000 };
+    const result = checkThresholds(metrics);
+
+    assert({
+      given: "body at 499 lines",
+      should: "return a 160-line soft warning",
+      actual: result.warnings.some((w) => w.includes("160")),
+      expected: true,
+    });
+
+    assert({
+      given: "body at 499 lines",
+      should: "not produce a hard error",
+      actual: result.errors,
+      expected: [],
+    });
+  });
+
+  test("frontmatter at 99 tokens (just below warning threshold)", () => {
+    const metrics = { frontmatterTokens: 99, bodyLines: 50, bodyTokens: 1000 };
+    const result = checkThresholds(metrics);
+
+    assert({
+      given: "frontmatter at 99 tokens",
+      should: "return no frontmatter warning",
+      actual: result.warnings.filter((w) => w.includes("Frontmatter")),
+      expected: [],
+    });
+
+    assert({
+      given: "frontmatter at 99 tokens",
+      should: "return no errors",
+      actual: result.errors,
+      expected: [],
+    });
+  });
+
+  test("body at 4999 tokens (just below warning threshold)", () => {
+    const metrics = { frontmatterTokens: 10, bodyLines: 50, bodyTokens: 4999 };
+    const result = checkThresholds(metrics);
+
+    assert({
+      given: "body at 4999 tokens",
+      should: "return no token warning",
+      actual: result.warnings.filter((w) => w.includes("5000")),
+      expected: [],
+    });
+
+    assert({
+      given: "body at 4999 tokens",
+      should: "return no errors",
+      actual: result.errors,
+      expected: [],
+    });
+  });
+});
+
+describe("validateSkillContent", () => {
+  test("valid skill with matching dir name", () => {
+    const content = `---
+name: aidd-my-skill
+description: A test skill.
+---
+# My Skill
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given: "valid SKILL.md content and matching directory name",
+      should: "return no errors and computed metrics",
+      actual: result.errors,
+      expected: [],
+    });
+
+    assert({
+      given: "valid SKILL.md content",
+      should: "return bodyLines metric",
+      actual: typeof result.metrics.bodyLines,
+      expected: "number",
+    });
+  });
+
+  test("mismatched directory name", () => {
+    const content = `---
+name: aidd-my-skill
+description: A test skill.
+---
+# My Skill`;
+
+    const result = validateSkillContent(content, "other-dir");
+
+    assert({
+      given: "SKILL.md name does not match directory name",
+      should: "return an error",
+      actual: result.errors.length > 0,
+      expected: true,
+    });
+  });
+
+  test("missing frontmatter name", () => {
+    const content = `---
+description: No name here.
+---
+# My Skill`;
+
+    const result = validateSkillContent(content, "");
+
+    assert({
+      given: "frontmatter without a name field",
+      should: "return an error",
+      actual: result.errors.length > 0,
+      expected: true,
+    });
+  });
+
+  test("valid description passes without description-related errors", () => {
+    const content = `---
+name: aidd-my-skill
+description: A valid skill description.
+---
+# My Skill
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given: "a skill with a valid description",
+      should: "return no errors",
+      actual: result.errors,
+      expected: [],
+    });
+  });
+
+  test("missing description field fails with error", () => {
+    const content = `---
+name: aidd-my-skill
+---
+# My Skill
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given: "a skill with no description field",
+      should: "return a description required error",
+      actual: result.errors.some((e) => e.includes("Description is required")),
+      expected: true,
+    });
+  });
+
+  test("empty string description field fails with error", () => {
+    const content = `---
+name: aidd-my-skill
+description: ""
+---
+# My Skill
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given: "a skill with an empty string description",
+      should: "return a description required error",
+      actual: result.errors.some((e) => e.includes("Description is required")),
+      expected: true,
+    });
+  });
+
+  test("description exceeding 1024 characters fails with error", () => {
+    const longDescription = "a".repeat(1025);
+    const content = `---
+name: aidd-my-skill
+description: ${longDescription}
+---
+# My Skill
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given: "a skill with a description longer than 1024 characters",
+      should: "return a description length error",
+      actual: result.errors.some((e) =>
+        e.includes("Description must be 1024 characters or fewer"),
+      ),
+      expected: true,
+    });
+  });
+
+  test("description of exactly 1024 characters passes without error", () => {
+    const maxDescription = "a".repeat(1024);
+    const content = `---
+name: aidd-my-skill
+description: ${maxDescription}
+---
+# My Skill
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given: "a skill with a description of exactly 1024 characters",
+      should: "not return a description length error",
+      actual: result.errors.some((e) =>
+        e.includes("Description must be 1024 characters or fewer"),
+      ),
+      expected: false,
+    });
+  });
+
+  test("quoted name field is stripped of quotes before validation", () => {
+    const content = `---
+name: "aidd-my-skill"
+description: A test skill.
+---
+# My Skill
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given:
+        'a skill with name: "aidd-my-skill" (YAML double-quoted) and matching directory',
+      should: "return no name-related errors",
+      actual: result.errors,
+      expected: [],
+    });
+  });
+
+  test("single-quoted name field is stripped of quotes before validation", () => {
+    const content = `---
+name: 'aidd-my-skill'
+description: A test skill.
+---
+# My Skill
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given:
+        "a skill with name: 'aidd-my-skill' (YAML single-quoted) and matching directory",
+      should: "return no name-related errors",
+      actual: result.errors,
+      expected: [],
+    });
+  });
+
+  test("malformed YAML frontmatter returns an Invalid YAML error instead of throwing", () => {
+    const content = `---
+name: aidd-my-skill
+description: [broken
+---
+# My Skill
+
+Body content here.`;
+
+    let result;
+    let threw = false;
+    try {
+      result = validateSkillContent(content, "aidd-my-skill");
+    } catch {
+      threw = true;
+    }
+
+    assert({
+      given: "a skill with malformed YAML in frontmatter",
+      should: "not throw an exception",
+      actual: threw,
+      expected: false,
+    });
+
+    assert({
+      given: "a skill with malformed YAML in frontmatter",
+      should: 'return an error containing "Invalid YAML"',
+      actual: result.errors.some((e) => e.includes("Invalid YAML")),
+      expected: true,
+    });
+  });
+
+  test("unknown frontmatter key produces an error via validateSkillContent", () => {
+    const content = `---
+name: aidd-my-skill
+description: A valid skill description.
+unknown-key: some value
+---
+# My Skill
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given: "a skill with an unknown frontmatter key",
+      should: "return an error naming the unknown key",
+      actual: result.errors.some((e) =>
+        e.includes("Unknown frontmatter key: unknown-key"),
+      ),
+      expected: true,
+    });
+  });
+
+  test("inline YAML comment on name field does not corrupt name validation", () => {
+    const content = `---
+name: aidd-my-skill # inline comment
+description: A test skill.
+---
+# My Skill
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given:
+        "a SKILL.md with an inline YAML comment on the name field (name: aidd-my-skill # comment)",
+      should: "validate name correctly and return no errors",
+      actual: result.errors,
+      expected: [],
+    });
+  });
+
+  test("degenerate frontmatter that is a bare scalar returns a YAML mapping error without throwing", () => {
+    const content = `---
+just a string
+---
+# My Skill
+
+Body content here.`;
+
+    let result;
+    let threw = false;
+    try {
+      result = validateSkillContent(content, "aidd-my-skill");
+    } catch {
+      threw = true;
+    }
+
+    assert({
+      given:
+        "a SKILL.md whose frontmatter is a bare YAML scalar (not a mapping)",
+      should: "not throw an exception",
+      actual: threw,
+      expected: false,
+    });
+
+    assert({
+      given:
+        "a SKILL.md whose frontmatter is a bare YAML scalar (not a mapping)",
+      should: 'return an error containing "must be a YAML mapping"',
+      actual: result.errors.some((e) => e.includes("must be a YAML mapping")),
+      expected: true,
+    });
+  });
+});
+
+describe("validateFrontmatterKeys", () => {
+  test("all allowed keys present returns no errors", () => {
+    const frontmatterObj = {
+      name: "aidd-my-skill",
+      description: "A test skill.",
+      license: "MIT",
+      compatibility: "node >= 18",
+      metadata: { alwaysApply: "true" },
+      "allowed-tools": "read write",
+    };
+
+    assert({
+      given: "a frontmatter object with only allowed keys",
+      should: "return no errors",
+      actual: validateFrontmatterKeys(frontmatterObj),
+      expected: [],
+    });
+  });
+
+  test("one unknown key returns one error naming the key", () => {
+    const frontmatterObj = {
+      name: "aidd-my-skill",
+      description: "A test skill.",
+      "unknown-key": "some value",
+    };
+
+    assert({
+      given: "a frontmatter object with one unknown key",
+      should: "return one error naming the key",
+      actual: validateFrontmatterKeys(frontmatterObj),
+      expected: ["Unknown frontmatter key: unknown-key"],
+    });
+  });
+
+  test("multiple unknown keys return multiple errors", () => {
+    const frontmatterObj = {
+      name: "aidd-my-skill",
+      description: "A test skill.",
+      "bad-key": "x",
+      "another-bad-key": "y",
+    };
+
+    const errors = validateFrontmatterKeys(frontmatterObj);
+
+    assert({
+      given: "a frontmatter object with two unknown keys",
+      should: "return two errors",
+      actual: errors.length,
+      expected: 2,
+    });
+
+    assert({
+      given: "a frontmatter object with two unknown keys",
+      should: "name first unknown key in an error",
+      actual: errors.some((e) => e.includes("bad-key")),
+      expected: true,
+    });
+
+    assert({
+      given: "a frontmatter object with two unknown keys",
+      should: "name second unknown key in an error",
+      actual: errors.some((e) => e.includes("another-bad-key")),
+      expected: true,
+    });
+  });
+});

--- a/ai/skills/aidd-upskill/scripts/validate-skill.test.js
+++ b/ai/skills/aidd-upskill/scripts/validate-skill.test.js
@@ -74,6 +74,8 @@ description: A test skill.
 ---
 # My Skill
 
+## Process
+
 Body content here.`;
 
     const result = parseSkillMd(content);
@@ -89,7 +91,7 @@ Body content here.`;
       given: "SKILL.md content with valid frontmatter",
       should: "return body without frontmatter",
       actual: result.body,
-      expected: "# My Skill\n\nBody content here.",
+      expected: "# My Skill\n\n## Process\n\nBody content here.",
     });
   });
 
@@ -114,7 +116,7 @@ Body content here.`;
 
   test("CRLF line endings", () => {
     const content =
-      "---\r\nname: aidd-my-skill\r\ndescription: A test skill.\r\n---\r\n# My Skill\r\n\r\nBody content here.";
+      "---\r\nname: aidd-my-skill\r\ndescription: A test skill.\r\n---\r\n# My Skill\r\n\r\n## Process\r\n\r\nBody content here.";
     const result = parseSkillMd(content);
 
     assert({
@@ -128,7 +130,7 @@ Body content here.`;
       given: "SKILL.md content with CRLF line endings",
       should: "return body without frontmatter block",
       actual: result.body,
-      expected: "# My Skill\r\n\r\nBody content here.",
+      expected: "# My Skill\r\n\r\n## Process\r\n\r\nBody content here.",
     });
   });
 });
@@ -149,8 +151,8 @@ describe("validateName", () => {
     assert({
       given: "a name without the aidd- prefix",
       should: "return an error requiring the aidd- prefix",
-      actual: errors[0],
-      expected: "Name must start with 'aidd-' prefix",
+      actual: errors.some((e) => e.includes("aidd-")),
+      expected: true,
     });
   });
 
@@ -160,15 +162,15 @@ describe("validateName", () => {
     assert({
       given: "a name with uppercase letters",
       should: "return an error requiring lowercase alphanumeric + hyphens",
-      actual: errors[0],
-      expected: "Name must be lowercase alphanumeric + hyphens only",
+      actual: errors.some((e) => e.includes("lowercase alphanumeric")),
+      expected: true,
     });
 
     assert({
       given: "a name with uppercase letters",
       should: "also return an error requiring the aidd- prefix",
-      actual: errors[1],
-      expected: "Name must start with 'aidd-' prefix",
+      actual: errors.some((e) => e.includes("aidd-")),
+      expected: true,
     });
   });
 
@@ -178,15 +180,15 @@ describe("validateName", () => {
     assert({
       given: "a name starting with a hyphen",
       should: "return an error requiring the aidd- prefix",
-      actual: errors[0],
-      expected: "Name must start with 'aidd-' prefix",
+      actual: errors.some((e) => e.includes("aidd-")),
+      expected: true,
     });
 
     assert({
       given: "a name starting with a hyphen",
       should: "return an error about leading/trailing hyphen",
-      actual: errors[1],
-      expected: "Name must not start or end with hyphen",
+      actual: errors.some((e) => e.includes("start or end with hyphen")),
+      expected: true,
     });
   });
 
@@ -196,15 +198,15 @@ describe("validateName", () => {
     assert({
       given: "a name ending with a hyphen",
       should: "return an error requiring the aidd- prefix",
-      actual: errors[0],
-      expected: "Name must start with 'aidd-' prefix",
+      actual: errors.some((e) => e.includes("aidd-")),
+      expected: true,
     });
 
     assert({
       given: "a name ending with a hyphen",
       should: "return an error about leading/trailing hyphen",
-      actual: errors[1],
-      expected: "Name must not start or end with hyphen",
+      actual: errors.some((e) => e.includes("start or end with hyphen")),
+      expected: true,
     });
   });
 
@@ -214,15 +216,15 @@ describe("validateName", () => {
     assert({
       given: "a name with consecutive hyphens",
       should: "return an error requiring the aidd- prefix",
-      actual: errors[0],
-      expected: "Name must start with 'aidd-' prefix",
+      actual: errors.some((e) => e.includes("aidd-")),
+      expected: true,
     });
 
     assert({
       given: "a name with consecutive hyphens",
       should: "return an error about consecutive hyphens",
-      actual: errors[1],
-      expected: "Name must not contain consecutive hyphens",
+      actual: errors.some((e) => e.includes("consecutive hyphens")),
+      expected: true,
     });
   });
 
@@ -499,6 +501,8 @@ description: A test skill.
 ---
 # My Skill
 
+## Process
+
 Body content here.`;
 
     const result = validateSkillContent(content, "aidd-my-skill");
@@ -558,6 +562,8 @@ description: A valid skill description.
 ---
 # My Skill
 
+## Process
+
 Body content here.`;
 
     const result = validateSkillContent(content, "aidd-my-skill");
@@ -575,6 +581,8 @@ Body content here.`;
 name: aidd-my-skill
 ---
 # My Skill
+
+## Process
 
 Body content here.`;
 
@@ -595,6 +603,8 @@ description: ""
 ---
 # My Skill
 
+## Process
+
 Body content here.`;
 
     const result = validateSkillContent(content, "aidd-my-skill");
@@ -614,6 +624,8 @@ name: aidd-my-skill
 description: ${longDescription}
 ---
 # My Skill
+
+## Process
 
 Body content here.`;
 
@@ -637,6 +649,8 @@ description: ${maxDescription}
 ---
 # My Skill
 
+## Process
+
 Body content here.`;
 
     const result = validateSkillContent(content, "aidd-my-skill");
@@ -658,6 +672,8 @@ description: A test skill.
 ---
 # My Skill
 
+## Process
+
 Body content here.`;
 
     const result = validateSkillContent(content, "aidd-my-skill");
@@ -678,6 +694,8 @@ description: A test skill.
 ---
 # My Skill
 
+## Process
+
 Body content here.`;
 
     const result = validateSkillContent(content, "aidd-my-skill");
@@ -697,6 +715,8 @@ name: aidd-my-skill
 description: [broken
 ---
 # My Skill
+
+## Process
 
 Body content here.`;
 
@@ -731,6 +751,8 @@ unknown-key: some value
 ---
 # My Skill
 
+## Process
+
 Body content here.`;
 
     const result = validateSkillContent(content, "aidd-my-skill");
@@ -752,6 +774,8 @@ description: A test skill.
 ---
 # My Skill
 
+## Process
+
 Body content here.`;
 
     const result = validateSkillContent(content, "aidd-my-skill");
@@ -770,6 +794,8 @@ Body content here.`;
 just a string
 ---
 # My Skill
+
+## Process
 
 Body content here.`;
 
@@ -794,6 +820,45 @@ Body content here.`;
         "a SKILL.md whose frontmatter is a bare YAML scalar (not a mapping)",
       should: 'return an error containing "must be a YAML mapping"',
       actual: result.errors.some((e) => e.includes("must be a YAML mapping")),
+      expected: true,
+    });
+  });
+
+  test("missing top-level heading", () => {
+    const content = `---
+name: aidd-my-skill
+description: A test skill.
+---
+
+## Process
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given: "a SKILL.md without a top-level heading",
+      should: "return an error about missing # Title",
+      actual: result.errors.some((e) => e.includes("top-level heading")),
+      expected: true,
+    });
+  });
+
+  test("missing Process/Steps section", () => {
+    const content = `---
+name: aidd-my-skill
+description: A test skill.
+---
+# My Skill
+
+Body content here.`;
+
+    const result = validateSkillContent(content, "aidd-my-skill");
+
+    assert({
+      given: "a SKILL.md without a ## Steps or ## Process section",
+      should: "return an error about missing section",
+      actual: result.errors.some((e) => e.includes("## Steps or ## Process")),
       expected: true,
     });
   });

--- a/ai/skills/index.md
+++ b/ai/skills/index.md
@@ -32,4 +32,5 @@
 - aidd-tdd - Systematic test-driven development with proper test isolation. Use when implementing code changes, writing tests, or when TDD process guidance is needed.
 - aidd-timing-safe-compare - Security rule for timing-safe secret comparison. Use SHA3-256 hashing instead of timing-safe compare functions. Use when reviewing or implementing secret comparisons, token validation, CSRF tokens, or API key checks.
 - aidd-ui - Design beautiful and friendly user interfaces and experiences. Use when building UI components, styling, animations, accessibility, responsive design, or working with design systems.
+- aidd-upskill - Guide for crafting high-quality AIDD skills. Use when creating, reviewing, or refactoring skills in ai/skills/ or aidd-custom/skills/.
 - aidd-user-testing - Generate human and AI agent test scripts from user journey specifications. Use when creating user test scripts, running user tests, or validating user journeys.

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "url": "git+https://github.com/paralleldrive/aidd.git"
   },
   "scripts": {
+    "build:validate-skill": "bun build --compile ai/skills/aidd-upskill/scripts/validate-skill.js --outfile ai/skills/aidd-upskill/scripts/validate-skill",
     "check-status": "[ -n \"$(git status --porcelain)\" ] && { echo '❌ Uncommitted changes'; exit 1; } || echo '✅ Git status is clean.'",
     "format": "npx @biomejs/biome format --write . && echo 'Format complete.'",
     "format:check": "npx @biomejs/biome check && echo 'Check complete.'",
@@ -106,6 +107,7 @@
     "release": "node release.js",
     "test": "vitest run && echo 'Test complete.' && npm run -s lint && npm run -s typecheck",
     "test:ai-eval": "riteway ai ai-evals/aidd-review/review-skill-test.sudo --runs 1 --threshold 75 --timeout 600000 --agent claude --color --save-responses",
+    "test:ai-eval:upskill": "riteway ai ai-evals/aidd-upskill/*.sudo --runs 1 --threshold 75 --timeout 600000 --agent claude --color --save-responses",
     "test:e2e": "vitest run **/*-e2e.test.js && echo 'E2E tests complete.'",
     "test:unit": "vitest run --exclude '**/*-e2e.test.js' && echo 'Unit tests complete.' && npm run -s lint && npm run -s typecheck",
     "toc": "doctoc README.md",

--- a/tasks/aidd-upskill-epic.md
+++ b/tasks/aidd-upskill-epic.md
@@ -1,0 +1,40 @@
+# aidd-upskill Epic
+
+**Goal**: A skill that guides agents to create and review high-quality AIDD skills.
+
+## Skill Design
+
+- Given an agent is designing a skill, should apply a function framing (`f: Input → Output`) as the primary design lens before committing to structure.
+- Given two skills share the same `f`, should extract a shared abstraction rather than duplicating.
+- Given a candidate abstraction cannot be named, should not be treated as an abstraction yet.
+- Given a skill is being designed or reviewed, should apply the Function Test: name `f`, identify parameters vs defaults, determine CLI vs AI prompt, confirm recomposability.
+
+## Create Pipeline
+
+- Given the create pipeline documented in `ai/skills/aidd-upskill/references/process.md`, should treat `discoverRelatedSkills` and `researchBestPractices` as sub-steps inside `gatherRequirements`, not as separate top-level pipeline stages that would run before those outputs exist.
+- Given `/aidd-upskill create [name]` is invoked, should infer requirements from context rather than blocking on user input; any gaps should be stated as explicit assumptions before proceeding.
+- Given a plan has been built, should validate it via `/aidd-review` and resolve issues via `/aidd-fix` before drafting — should not await explicit user approval.
+- Given a skill is being created, should produce a `README.md` containing what the skill is, why it is useful, and a command reference with usage examples.
+
+## Review Pipeline
+
+- Given `/aidd-upskill review [target]` is invoked, should run all checks and produce a per-check pass/fail table with an overall verdict.
+- Given a skill is under review, should scan SKILL.md and all reference files for duplicated information and identify the single source of truth for each.
+- Given a skill README is under review, should flag if it is missing, lacks what/why/commands, or contains implementation details or process narratives.
+
+## README Authoring
+
+- Given a skill README is authored, should not contain implementation details, process pipeline descriptions, or internal narratives.
+
+## Validator CLI
+
+- Given `validate-skill` is run against a skill directory, should report name errors and size threshold warnings.
+- Given `validate-skill` is executed as the program entry point (including when packaged as a Bun-compiled binary), should run the CLI and validate the target directory instead of treating the script as an imported library only.
+- Given the module is loaded as a CLI entry point, should determine `isMain` by calling `resolveIsMainEntry` instead of duplicating its logic inline.
+- Given a SKILL.md frontmatter field value contains an inline YAML comment (e.g. `name: aidd-my-skill # comment`), should validate `name` and `description` correctly without treating the comment as part of the value.
+- Given `yaml.load` returns a non-object value for degenerate frontmatter (e.g. a bare scalar string), should return an error containing "must be a YAML mapping" without throwing.
+
+## Eval Tests
+
+- Given `runFunctionTest` is applied to a skill description, should correctly name `f`, distinguish parameters from defaults, and reach the correct CLI vs AI prompt verdict.
+- Given `deduplicateWithCaveman()` is applied to a SKILL.md and reference file containing duplicated content, should identify the duplicate and name the canonical location.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Split from PR #94. One skill per PR per project standards.

## What

Adds the `/aidd-upskill` skill — a guide for creating and reviewing high-quality AIDD agent skills following the AgentSkills.io specification and SudoLang authoring patterns.

## Changes

### New files
- `ai/skills/aidd-upskill/` — Full skill directory with SKILL.md, README.md, references (process.md, types.md), and scripts (validate-skill.js + tests)
- `ai/commands/aidd-upskill.md` — Command definition
- `ai-evals/aidd-upskill/` — AI eval tests (caveman, dedup, function tests) with fixtures
- `tasks/aidd-upskill-epic.md` — Epic documentation

### Modified files
- `ai/skills/aidd-agent-orchestrator/SKILL.md` — Added upskill to agent routing
- `ai/skills/aidd-please/SKILL.md` — Added `/aidd-upskill` command entry
- `ai/commands/index.md` — Added upskill entry
- `ai/skills/index.md` — Added upskill entry
- `.gitignore` — Added compiled validate-skill binary
- `package.json` — Added `build:validate-skill` and `test:ai-eval:upskill` scripts

### Not included (RTC-only changes from PR #94)
- `ai/skills/aidd-review/SKILL.md` changes (RTC refactor only, no upskill content)
- `ai/skills/aidd-please/SKILL.md` RTC refactor (only upskill command line included)

## Review

Ran the full `/aidd-upskill review` pipeline against this skill:

| Check | Result | Detail |
|-------|--------|--------|
| runFunctionTest | ✅ | `createSkill` and `reviewSkill` clearly named; parameters/defaults well separated; judgment-based → AI prompt; deterministic validation → CLI tool |
| checkRequiredSections | ✅ | `# aidd-upskill` title and `## Process` section present |
| checkSizeMetrics | ✅ | 42 frontmatter tokens, 129 body lines, 989 body tokens — all within thresholds |
| checkCommandSeparation | ✅ | Pipeline stages separate thinking from effects; review is pure thinking |
| checkReadme | ✅ | Contains what/why/commands; no implementation details or process narratives |
| deduplicate | ✅ | Types in types.md only, pipelines in process.md only, Function Test in SKILL.md only; command text overlap between SKILL.md and README.md is by design |

**Overall verdict: ✅ Pass**

## Testing

- All 544 unit tests pass
- All 49 e2e tests pass
- Lint and typecheck clean
- `validate-skill` passes on the skill itself

<!--
REVIEWER INSTRUCTIONS:
Please use the AI review command to conduct a thorough code review.
Run: ai/commands/review.md
Make sure to reference the JavaScript style guide: ai/skills/aidd-javascript/SKILL.md
This will help ensure code quality, best practices, and adherence to project standards.
-->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69faa1ce-41ab-40e2-9bdb-197372505d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69faa1ce-41ab-40e2-9bdb-197372505d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

