### PR TITLE
fix(ai-eval): use bash globstar to find all test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "prepare": "husky",
     "release": "node release.js",
     "test": "vitest run && echo 'Test complete.' && npm run -s lint && npm run -s typecheck",
-    "test:ai-eval": "riteway ai 'ai-evals/**/*.sudo' --runs 1 --threshold 75 --timeout 600000 --agent claude --color --save-responses",
+    "test:ai-eval": "bash -c 'shopt -s globstar; for f in ai-evals/**/*-test.sudo; do riteway ai \"$f\" --runs 1 --threshold 75 --timeout 600000 --agent claude --color --save-responses || exit 1; done'",
     "test:e2e": "vitest run **/*-e2e.test.js && echo 'E2E tests complete.'",
     "test:unit": "vitest run --exclude '**/*-e2e.test.js' && echo 'Unit tests complete.' && npm run -s lint && npm run -s typecheck",
     "toc": "doctoc README.md",


### PR DESCRIPTION
## Summary
- The previous fix (#195) used a quoted glob that `riteway ai` tried to open as a literal path, causing ENOENT on the runner.
- Use `bash -c 'shopt -s globstar; for f in ...'` to properly expand `**/*-test.sudo` and run each file individually.
- Stops on first failure via `|| exit 1`.

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` and verify all 10 `.sudo` files are found and executed