### PR TITLE
fix(aidd-pr): add constraint to commit directly to PR branch

### DIFF
--- a/ai/skills/aidd-pr/SKILL.md
+++ b/ai/skills/aidd-pr/SKILL.md
@@ -25,6 +25,7 @@ Constraints {
   Paginate GraphQL queries using pageInfo.hasNextPage until all results are retrieved — do not assume first: 100 covers all threads
   Do not close any other PRs
   Do not touch any git branches other than the PR's branch as determined via `gh pr view`
+  Delegation prompts must explicitly instruct the sub-agent to commit directly to the PR branch and not create a new branch
 }
 
 DelegateSubtasks {


### PR DESCRIPTION
## Summary
- Add explicit constraint to aidd-pr SKILL.md: delegation prompts must instruct sub-agents to commit directly to the PR branch and not create a new branch
- This matches the existing ai-eval assertion in `step-3-delegation-test.sudo` that was failing because the skill lacked this explicit instruction

## Test plan
- [ ] Trigger AI eval workflow and verify `step-3-delegation-test.sudo` passes 5/5