### PR TITLE
fix(aidd-pr): strengthen Step 3 delegation prompt requirements

### DIFF
--- a/ai/skills/aidd-pr/SKILL.md
+++ b/ai/skills/aidd-pr/SKILL.md
@@ -81,8 +81,12 @@ resolveAddressed(triageResult) {
 
 ### Step 3 — Delegate (thinking)
 delegateRemaining(triageResult) => delegationPrompts {
+  Do NOT fix code directly — only produce prompt text for sub-agents to execute later.
   1. For each remaining issue, generate a `/aidd-fix` delegation prompt
-  2. Each prompt targets one issue, referencing the specific file, line, and PR branch
+  2. Each prompt must:
+     - Start with `/aidd-fix` on the first line
+     - Reference the specific file, line, and review comment
+     - Instruct the sub-agent to commit directly to the PR branch and not create a new branch
   3. Wrap each prompt in a markdown code block for easy copy-paste or sub-agent dispatch
 }
 


### PR DESCRIPTION
## Summary
- The agent was sometimes fixing code inline instead of generating `/aidd-fix` delegation prompts, causing step-3-delegation-test to fail (1/5 on last run)
- Strengthen Step 3 in SKILL.md with explicit requirements:
  - "Do NOT fix code directly — only produce prompt text"
  - Each prompt must start with `/aidd-fix` on the first line
  - Must reference specific file, line, and review comment
  - Must instruct sub-agent to commit to PR branch, not create new one
  - Must be wrapped in a markdown code block

## Test plan
- [ ] Trigger AI eval workflow and verify `step-3-delegation-test.sudo` passes 5/5