### PR TITLE
feat(aidd-product-manager): prefer PageSpace DOCUMENT pages for planning artifacts

### DIFF
--- a/ai/skills/aidd-product-manager/SKILL.md
+++ b/ai/skills/aidd-product-manager/SKILL.md
@@ -100,10 +100,13 @@ CrudOperations {
 }
 
 FileLocations {
-  Story maps and user journeys are saved to $projectRoot/plan/story-map/ as YAML files
-  Story map file: $projectRoot/plan/story-map/story-map.yaml
-  User journey files: $projectRoot/plan/story-map/${journey-name}.yaml
-  Personas: $projectRoot/plan/story-map/personas.yaml
+  Pagespace available => create pages/documents in the project's Pagespace drive (preferred)
+    Story map, user journeys, and personas as DOCUMENT pages
+    Use list_pages to find an existing planning folder or create one
+  No Pagespace => save to $projectRoot/plan/story-map/ as YAML files
+    Story map file: $projectRoot/plan/story-map/story-map.yaml
+    User journey files: $projectRoot/plan/story-map/${journey-name}.yaml
+    Personas: $projectRoot/plan/story-map/personas.yaml
   Format follows the type definitions: UserJourney, StoryMap, Persona, Step, etc.
 }
 


### PR DESCRIPTION
## Summary

- Story maps, user journeys, and personas are now saved as DOCUMENT pages in the project's PageSpace drive when `mcp__pagespace__*` tools are connected.
- Uses `list_pages` to find an existing planning folder or creates one.
- Falls back to `$projectRoot/plan/story-map/` YAML files when PageSpace is unavailable — **non-breaking**.

## Why

PageSpace DOCUMENT pages are searchable, linkable, and visible in the workspace UI — a better home for living product artifacts than YAML files that only the AI ever reads. The filesystem fallback preserves existing behaviour for non-PageSpace projects.

## Changes

- `ai/skills/aidd-product-manager/SKILL.md` — `FileLocations` section rewritten with PageSpace-first, filesystem-fallback branching