### PR TITLE
feat(aidd-user-testing): prefer PageSpace DOCUMENT pages for test scripts

### DIFF
--- a/ai/skills/aidd-user-testing/SKILL.md
+++ b/ai/skills/aidd-user-testing/SKILL.md
@@ -120,7 +120,9 @@ generateScripts(journey) => {
 
 ## FileLocations
 
-User test scripts are saved to $projectRoot/plan/ folder (create if not present):
+Pagespace available => save test scripts as DOCUMENT pages in the project's Pagespace drive (preferred)
+  Human and agent scripts as child pages under a "User Testing" folder
+No Pagespace => save to $projectRoot/plan/ folder (create if not present):
 - Human test scripts: $projectRoot/plan/${journey-name}-human-test.md
 - Agent test scripts: $projectRoot/plan/${journey-name}-agent-test.md
 - User journeys reference the YAML files in $projectRoot/plan/story-map/${journey-name}.yaml


### PR DESCRIPTION
## Summary

- Human and agent test scripts are now saved as DOCUMENT pages under a "User Testing" folder in the project's PageSpace drive when `mcp__pagespace__*` tools are connected.
- Falls back to `$projectRoot/plan/` when PageSpace is unavailable — **non-breaking**.

## Why

Test scripts stored as PageSpace DOCUMENT pages are visible and shareable in the workspace alongside the user journeys and personas from `aidd-product-manager`. Keeping the full testing workflow in one place makes it easier to iterate on scripts across sessions.

## Changes

- `ai/skills/aidd-user-testing/SKILL.md` — `FileLocations` section updated with PageSpace-first, filesystem-fallback branching